### PR TITLE
Support Null Status in UnmarshalJSON

### DIFF
--- a/int4.go
+++ b/int4.go
@@ -201,13 +201,17 @@ func (src Int4) MarshalJSON() ([]byte, error) {
 }
 
 func (dst *Int4) UnmarshalJSON(b []byte) error {
-	var n int32
+	var n *int32
 	err := json.Unmarshal(b, &n)
 	if err != nil {
 		return err
 	}
 
-	*dst = Int4{Int: n, Status: Present}
+	if n == nil {
+		*dst = Int4{Status: Null}
+	} else {
+		*dst = Int4{Int: *n, Status: Present}
+	}
 
 	return nil
 }

--- a/int4_test.go
+++ b/int4_test.go
@@ -141,3 +141,24 @@ func TestInt4AssignTo(t *testing.T) {
 		}
 	}
 }
+
+func TestInt4UnmarshalJSON(t *testing.T) {
+	successfulTests := []struct {
+		source string
+		result pgtype.Int4
+	}{
+		{source: "null", result: pgtype.Int4{Int: 0, Status: pgtype.Null}},
+		{source: "1", result: pgtype.Int4{Int: 1, Status: pgtype.Present}},
+	}
+	for i, tt := range successfulTests {
+		var r pgtype.Int4
+		err := r.UnmarshalJSON([]byte(tt.source))
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if r != tt.result {
+			t.Errorf("%d: expected %v to convert to %v, but it was %v", i, tt.source, tt.result, r)
+		}
+	}
+}

--- a/int8.go
+++ b/int8.go
@@ -187,13 +187,17 @@ func (src Int8) MarshalJSON() ([]byte, error) {
 }
 
 func (dst *Int8) UnmarshalJSON(b []byte) error {
-	var n int64
+	var n *int64
 	err := json.Unmarshal(b, &n)
 	if err != nil {
 		return err
 	}
 
-	*dst = Int8{Int: n, Status: Present}
+	if n == nil {
+		*dst = Int8{Status: Null}
+	} else {
+		*dst = Int8{Int: *n, Status: Present}
+	}
 
 	return nil
 }

--- a/int8_test.go
+++ b/int8_test.go
@@ -142,3 +142,24 @@ func TestInt8AssignTo(t *testing.T) {
 		}
 	}
 }
+
+func TestInt8UnmarshalJSON(t *testing.T) {
+	successfulTests := []struct {
+		source string
+		result pgtype.Int8
+	}{
+		{source: "null", result: pgtype.Int8{Int: 0, Status: pgtype.Null}},
+		{source: "1", result: pgtype.Int8{Int: 1, Status: pgtype.Present}},
+	}
+	for i, tt := range successfulTests {
+		var r pgtype.Int8
+		err := r.UnmarshalJSON([]byte(tt.source))
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if r != tt.result {
+			t.Errorf("%d: expected %v to convert to %v, but it was %v", i, tt.source, tt.result, r)
+		}
+	}
+}

--- a/text.go
+++ b/text.go
@@ -152,13 +152,17 @@ func (src Text) MarshalJSON() ([]byte, error) {
 }
 
 func (dst *Text) UnmarshalJSON(b []byte) error {
-	var s string
+	var s *string
 	err := json.Unmarshal(b, &s)
 	if err != nil {
 		return err
 	}
 
-	*dst = Text{String: s, Status: Present}
+	if s == nil {
+		*dst = Text{Status: Null}
+	} else {
+		*dst = Text{String: *s, Status: Present}
+	}
 
 	return nil
 }

--- a/text_test.go
+++ b/text_test.go
@@ -121,3 +121,24 @@ func TestTextAssignTo(t *testing.T) {
 		}
 	}
 }
+
+func TestTextUnmarshalJSON(t *testing.T) {
+	successfulTests := []struct {
+		source string
+		result pgtype.Text
+	}{
+		{source: "null", result: pgtype.Text{String: "", Status: pgtype.Null}},
+		{source: "\"a\"", result: pgtype.Text{String: "a", Status: pgtype.Present}},
+	}
+	for i, tt := range successfulTests {
+		var r pgtype.Text
+		err := r.UnmarshalJSON([]byte(tt.source))
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if r != tt.result {
+			t.Errorf("%d: expected %v to convert to %v, but it was %v", i, tt.source, tt.result, r)
+		}
+	}
+}


### PR DESCRIPTION
See issue #16. This pull request adds support for `Status: Null` in the UnmarshalJSON method of those types that currently have one.