### PR TITLE
Use correct format verb for unknown type error

### DIFF
--- a/pgtype.go
+++ b/pgtype.go
@@ -404,7 +404,7 @@ func scanUnknownType(oid uint32, formatCode int16, buf []byte, dest interface{})
 	switch dest := dest.(type) {
 	case *string:
 		if formatCode == BinaryFormatCode {
-			return errors.Errorf("unknown oid %d in binary format cannot be scanned into %t", oid, dest)
+			return errors.Errorf("unknown oid %d in binary format cannot be scanned into %T", oid, dest)
 		}
 		*dest = string(buf)
 		return nil
@@ -415,7 +415,7 @@ func scanUnknownType(oid uint32, formatCode int16, buf []byte, dest interface{})
 		if nextDst, retry := GetAssignToDstType(dest); retry {
 			return scanUnknownType(oid, formatCode, buf, nextDst)
 		}
-		return errors.Errorf("unknown oid %d cannot be scanned into %t", oid, dest)
+		return errors.Errorf("unknown oid %d cannot be scanned into %T", oid, dest)
 	}
 }
 


### PR DESCRIPTION
%t for booleans is used instead of %T for types in two calls to `errors.Errorf`, fix this by changing %t to %T.