### PR TITLE
Introduce ScanRowValue and ROW helper functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "go.inferGopath": false,
+    "go.testEnvVars": {
+       "PGX_TEST_DATABASE": "user=postgres database=pgx_test host=127.0.0.1"
+    },
+}

--- a/binary/record.go
+++ b/binary/record.go
@@ -1,0 +1,78 @@
+package binary
+
+import (
+	"encoding/binary"
+
+	"github.com/jackc/pgio"
+	errors "golang.org/x/xerrors"
+)
+
+type RecordFieldIter struct {
+	rp  int
+	src []byte
+}
+
+// NewRecordFieldIterator creates iterator over binary representation
+// of record, aka ROW(), aka Composite
+func NewRecordFieldIterator(src []byte) (RecordFieldIter, int, error) {
+	rp := 0
+	if len(src[rp:]) < 4 {
+		return RecordFieldIter{}, 0, errors.Errorf("Record incomplete %v", src)
+	}
+
+	fieldCount := int(int32(binary.BigEndian.Uint32(src[rp:])))
+	rp += 4
+
+	return RecordFieldIter{
+		rp:  rp,
+		src: src,
+	}, fieldCount, nil
+}
+
+// Next returns next field decoded from record. eof is returned if no
+// more fields left to decode.
+func (fi *RecordFieldIter) Next() (fieldOID uint32, buf []byte, eof bool, err error) {
+	if fi.rp == len(fi.src) {
+		eof = true
+		return
+	}
+
+	if len(fi.src[fi.rp:]) < 8 {
+		err = errors.Errorf("Record incomplete %v", fi.src)
+		return
+	}
+	fieldOID = binary.BigEndian.Uint32(fi.src[fi.rp:])
+	fi.rp += 4
+
+	fieldLen := int(int32(binary.BigEndian.Uint32(fi.src[fi.rp:])))
+	fi.rp += 4
+
+	if fieldLen >= 0 {
+		if len(fi.src[fi.rp:]) < fieldLen {
+			err = errors.Errorf("Record incomplete rp=%d src=%v", fi.rp, fi.src)
+			return
+		}
+		buf = fi.src[fi.rp : fi.rp+fieldLen]
+		fi.rp += fieldLen
+	}
+
+	return
+}
+
+// RecordStart adds record header to the buf
+func RecordStart(buf []byte, fieldCount int) []byte {
+	return pgio.AppendUint32(buf, uint32(fieldCount))
+}
+
+// RecordAdd adds record field to the buf
+func RecordAdd(buf []byte, oid uint32, fieldBytes []byte) []byte {
+	buf = pgio.AppendUint32(buf, oid)
+	buf = pgio.AppendUint32(buf, uint32(len(fieldBytes)))
+	buf = append(buf, fieldBytes...)
+	return buf
+}
+
+// RecordAddNull adds null value as a field to the buf
+func RecordAddNull(buf []byte, oid uint32) []byte {
+	return pgio.AppendInt32(buf, int32(-1))
+}

--- a/composite.go
+++ b/composite.go
@@ -1,0 +1,128 @@
+package pgtype
+
+import (
+	errors "golang.org/x/xerrors"
+)
+
+type composite struct {
+	fields []Value
+	status Status
+}
+
+// helper struct to act both as a scanning target and query argument
+type rowValue struct {
+	args []interface{}
+}
+
+// Row helper function builds a value which can be both used to
+// "assemble" composite quiery arguments and to scan results back.
+//
+// When passed as an argument to query, values from Row args will
+// be assigned to corresponding fields in a composite type and a single
+// composite type will be passed to the PostgreSQL. Composite type need
+// to be registered in ConnInfo first. This is required so that pgx
+// can know which SQL types to use when constructing SQL composite argument
+//
+// When passed to Scan individual fields from composite query result
+// are assigned to corresponding Row arguments. First argument MUST
+// be of type *bool to flag when NULL value received. So total number
+// of Row arguments, when passed to Scan should be number of composite
+// fields you expect to read + 1
+func Row(fields ...interface{}) rowValue {
+	return rowValue{fields}
+}
+
+// Composite types is meant to be passed to ConnInfo.RegisterDataType only,
+// so it is made private on purpose. Once registered, it allows Row
+// function to correctly pass query arguments.
+func Composite(fields ...Value) *composite {
+	return &composite{fields, Undefined}
+}
+
+func (src composite) Get() interface{} {
+	switch src.status {
+	case Present:
+		return src
+	case Null:
+		return nil
+	default:
+		return src.status
+	}
+}
+
+// Set is called internally when passing query arguments.
+// Only valid src is a result of pgtype.Row() or nil
+func (dst *composite) Set(src interface{}) error {
+	if src == nil {
+		*dst = composite{status: Null}
+		return nil
+	}
+
+	switch value := src.(type) {
+	case rowValue:
+		if len(value.args) != len(dst.fields) {
+			return errors.Errorf("Number of fields don't match. Composite has %d fields", len(dst.fields))
+		}
+		for i, v := range value.args {
+			if err := dst.fields[i].Set(v); err != nil {
+				return err
+			}
+		}
+		dst.status = Present
+	default:
+		return errors.Errorf("Use pgtype.Row() as query parameter")
+	}
+
+	return nil
+}
+
+// AssignTo is never called on composite value directly, it is here
+// to satisfy Valuer interface
+func (src composite) AssignTo(dst interface{}) error {
+	return errors.New("BUG: should never be called, because pgtype.composite doesn't support decoding")
+}
+
+func (src composite) EncodeBinary(ci *ConnInfo, buf []byte) (newBuf []byte, err error) {
+	return EncodeRow(ci, buf, src.fields...)
+}
+
+// DecodeBinary here is just to make pgx use binary result format by default.
+// Users should be using Row function or their own types to scan composites
+func (src composite) DecodeBinary(ci *ConnInfo, buf []byte) (err error) {
+	return errors.New("Pass pgtype.Row() to Scan to deconstruct Composite")
+}
+
+// DecodeBinary is called when pgtype.Row() is passed to Scan() to
+// deconstruct composite value
+func (r rowValue) DecodeBinary(ci *ConnInfo, src []byte) error {
+	if len(r.args) == 0 {
+		return errors.New("pgtype.Row must have 'isNull *bool' as a first argument when used in Scan")
+	}
+
+	isNull, ok := r.args[0].(*bool)
+	if !ok {
+		return errors.New("pgtype.Row must have 'isNull *bool' as a first argument when used in Scan")
+	}
+	args := r.args[1:]
+
+	var record Record
+	if err := record.DecodeBinary(ci, src); err != nil {
+		return err
+	}
+
+	if record.Status == Null {
+		*isNull = true
+		return nil
+	}
+
+	if len(record.Fields) != len(args) {
+		return errors.Errorf("SQL composite can't be read, 'pgtype.Row' has wrong field cout. %d != %d", len(record.Fields), len(args))
+	}
+
+	for i, f := range record.Fields {
+		if err := f.AssignTo(args[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/composite.go
+++ b/composite.go
@@ -1,146 +1,153 @@
 package pgtype
 
 import (
+	"github.com/jackc/pgtype/binary"
 	errors "golang.org/x/xerrors"
 )
 
-type composite struct {
+type Composite struct {
 	fields []Value
-	status Status
+	Status Status
 }
 
-// helper struct to act both as a scanning target and query argument
-type rowValue struct {
-	args []interface{}
+// NewComposite creates a Composite object, which acts as a "schema" for
+// SQL composite values.
+// To pass Composite as SQL parameter first set it's fields, either by
+// passing initialized Value{} instances to NewComposite or by calling
+// SetFields method
+// To read composite fields back pass result of Scan() method
+// to query Scan function.
+func NewComposite(fields ...Value) *Composite {
+	return &Composite{fields, Present}
 }
 
-// Row helper function builds a value which can be both used to
-// "assemble" composite quiery arguments and to scan results back.
-//
-// When passed as an argument to query, values from Row args will
-// be assigned to corresponding fields in a composite type and a single
-// composite type will be passed to the PostgreSQL. Composite type need
-// to be registered in ConnInfo first. This is required so that pgx
-// can know which SQL types to use when constructing SQL composite argument
-//
-// When passed to Scan individual fields from composite query result
-// are assigned to corresponding Row arguments. First argument MUST
-// be of type *bool to flag when NULL value received. So total number
-// of Row arguments, when passed to Scan should be number of composite
-// fields you expect to read + 1
-func Row(fields ...interface{}) rowValue {
-	return rowValue{fields}
-}
-
-// Composite types is meant to be passed to ConnInfo.RegisterDataType only,
-// so it is made private on purpose. Once registered, it allows Row
-// function to correctly pass query arguments.
-func Composite(fields ...Value) *composite {
-	return &composite{fields, Undefined}
-}
-
-func (src composite) Get() interface{} {
-	switch src.status {
+func (src Composite) Get() interface{} {
+	switch src.Status {
 	case Present:
 		return src
 	case Null:
 		return nil
 	default:
-		return src.status
+		return src.Status
 	}
 }
 
 // Set is called internally when passing query arguments.
-// Only valid src is a result of pgtype.Row() or nil
-func (dst *composite) Set(src interface{}) error {
+func (dst *Composite) Set(src interface{}) error {
 	if src == nil {
-		*dst = composite{status: Null}
+		*dst = Composite{Status: Null}
 		return nil
 	}
 
 	switch value := src.(type) {
-	case rowValue:
-		if len(value.args) != len(dst.fields) {
+	case []Value:
+		if len(value) != len(dst.fields) {
 			return errors.Errorf("Number of fields don't match. Composite has %d fields", len(dst.fields))
 		}
-		for i, v := range value.args {
+		for i, v := range value {
 			if err := dst.fields[i].Set(v); err != nil {
 				return err
 			}
 		}
-		dst.status = Present
+		dst.Status = Present
 	default:
-		return errors.Errorf("Use pgtype.Row() as query parameter")
+		return errors.Errorf("Can not convert %v to Composite", src)
 	}
 
 	return nil
 }
 
-// AssignTo is never called on composite value directly, it is here
-// to satisfy Valuer interface
-func (src composite) AssignTo(dst interface{}) error {
-	return errors.New("BUG: should never be called, because pgtype.composite doesn't support decoding")
+// AssignTo should never be called on composite value directly
+func (src Composite) AssignTo(dst interface{}) error {
+	return errors.New("Pass Composite.Scan() to deconstruct composite")
 }
 
-func (src composite) EncodeBinary(ci *ConnInfo, buf []byte) (newBuf []byte, err error) {
+func (src Composite) EncodeBinary(ci *ConnInfo, buf []byte) (newBuf []byte, err error) {
+	switch src.Status {
+	case Null:
+		return nil, nil
+	case Undefined:
+		return nil, errUndefined
+	}
 	return EncodeRow(ci, buf, src.fields...)
 }
 
-// DecodeBinary here is just to make pgx use binary result format by default.
-// Users should be using Row function or their own types to scan composites
-func (src composite) DecodeBinary(ci *ConnInfo, buf []byte) (err error) {
-	return errors.New("Pass pgtype.Row() to Scan to deconstruct Composite")
-}
-
-// Row method creates composite BinaryEncoder. It's main purpose
-// is to build composite query argument inplace without registering
-// pgtype.Composite in ConnInfo first
-func (src composite) Row(values ...interface{}) BinaryEncoderFunc {
-	return func(ci *ConnInfo, buf []byte) ([]byte, error) {
-		if len(values) != len(src.fields) {
-			return nil, errors.Errorf("Number of fields don't match. Composite has %d fields", len(src.fields))
-		}
-		for i, v := range values {
-			if err := src.fields[i].Set(v); err != nil {
-				return nil, err
-			}
-		}
-		src.status = Present
-		return src.EncodeBinary(ci, buf)
-	}
-}
-
-// DecodeBinary is called when pgtype.Row() is passed to Scan() to
-// deconstruct composite value
-func (r rowValue) DecodeBinary(ci *ConnInfo, src []byte) error {
-	if len(r.args) == 0 {
-		return errors.New("pgtype.Row must have 'isNull *bool' as a first argument when used in Scan")
-	}
-
-	isNull, ok := r.args[0].(*bool)
-	if !ok {
-		return errors.New("pgtype.Row must have 'isNull *bool' as a first argument when used in Scan")
-	}
-	args := r.args[1:]
-
-	var record Record
-	if err := record.DecodeBinary(ci, src); err != nil {
-		return err
-	}
-
-	if record.Status == Null {
-		*isNull = true
+// DecodeBinary implements BinaryDecoder interface.
+// Opposite to Record, fields in a composite act as a "schema"
+// and decoding fails if SQL value can't be assigned due to
+// type mismatch
+func (dst *Composite) DecodeBinary(ci *ConnInfo, buf []byte) (err error) {
+	if buf == nil {
+		dst.Status = Null
 		return nil
 	}
 
-	if len(record.Fields) != len(args) {
-		return errors.Errorf("SQL composite can't be read, 'pgtype.Row' has wrong field cout. %d != %d", len(record.Fields), len(args))
+	fieldIter, fieldCount, err := binary.NewRecordFieldIterator(buf)
+	if err != nil {
+		return err
+	} else if len(dst.fields) != fieldCount {
+		return errors.Errorf("SQL composite can't be read, field count mismatch. expected %d , found %d", len(dst.fields), fieldCount)
 	}
 
-	for i, f := range record.Fields {
-		if err := f.AssignTo(args[i]); err != nil {
+	_, fieldBytes, eof, err := fieldIter.Next()
+
+	for i := 0; !eof; i++ {
+		if err != nil {
+			return err
+		}
+
+		binaryDecoder, ok := dst.fields[i].(BinaryDecoder)
+		if !ok {
+			return errors.New("Composite field doesn't support binary protocol")
+		}
+
+		if err = binaryDecoder.DecodeBinary(ci, fieldBytes); err != nil {
+			return err
+		}
+
+		_, fieldBytes, eof, err = fieldIter.Next()
+	}
+	dst.Status = Present
+
+	return nil
+}
+
+// Scan is a helper function to perform "nested" scan of
+// a composite value when scanning a query result row.
+// isNull is set if scanned value is NULL
+// Rest of arguments are set in the order of fields in the composite
+//
+// Use of Scan method doesn't modify original composite
+func (src Composite) Scan(isNull *bool, dst ...interface{}) BinaryDecoderFunc {
+	return func(ci *ConnInfo, buf []byte) error {
+		if err := src.DecodeBinary(ci, buf); err != nil {
+			return err
+		}
+
+		if src.Status == Null {
+			*isNull = true
+			return nil
+		}
+
+		for i, f := range src.fields {
+			if err := f.AssignTo(dst[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// SetFields sets Composite's fields to corresponding values
+func (dst *Composite) SetFields(values ...interface{}) error {
+	if len(values) != len(dst.fields) {
+		return errors.Errorf("Number of fields don't match. Composite has %d fields", len(dst.fields))
+	}
+	for i, v := range values {
+		if err := dst.fields[i].Set(v); err != nil {
 			return err
 		}
 	}
+	dst.Status = Present
 	return nil
 }

--- a/composite_bench_test.go
+++ b/composite_bench_test.go
@@ -101,24 +101,12 @@ func BenchmarkBinaryEncodingRow(b *testing.B) {
 	ci := pgtype.NewConnInfo()
 	f1 := 2
 	f2 := ptrS("bar")
+	c := pgtype.NewComposite(&pgtype.Int4{}, &pgtype.Text{})
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		c := pgtype.Composite(&pgtype.Int4{}, &pgtype.Text{})
-		c.Set(pgtype.Row(f1, f2))
+		c.SetFields(f1, f2)
 		buf, _ = c.EncodeBinary(ci, buf[:0])
-	}
-	x = buf
-}
-func BenchmarkBinaryEncodingRowInplace(b *testing.B) {
-	buf := make([]byte, 0, 128)
-	ci := pgtype.NewConnInfo()
-	f1 := 2
-	f2 := ptrS("bar")
-
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		buf, _ = pgtype.Composite(&pgtype.Int4{}, &pgtype.Text{}).Row(f1, f2).EncodeBinary(ci, buf[:0])
 	}
 	x = buf
 }
@@ -156,16 +144,18 @@ func BenchmarkBinaryDecodingHelpers(b *testing.B) {
 var gf1 int
 var gf2 *string
 
-func BenchmarkBinaryDecodingRow(b *testing.B) {
+func BenchmarkBinaryDecodingCompositeScan(b *testing.B) {
 	ci := pgtype.NewConnInfo()
 	buf, _ := MyType{4, ptrS("ABCDEFG")}.EncodeBinary(ci, nil)
 	var isNull bool
 	var f1 int
 	var f2 *string
 
+	c := pgtype.NewComposite(&pgtype.Int4{}, &pgtype.Text{})
+
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		err := pgtype.Row(&isNull, &f1, &f2).DecodeBinary(ci, buf)
+		err := c.Scan(&isNull, &f1, &f2).DecodeBinary(ci, buf)
 		E(err)
 	}
 	gf1 = f1

--- a/composite_bench_test.go
+++ b/composite_bench_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgtype/binary"
+	errors "golang.org/x/xerrors"
 )
 
 type MyCompositeRaw struct {
@@ -28,6 +29,45 @@ func (src MyCompositeRaw) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) (newBuf 
 		newBuf = binary.RecordAddNull(newBuf, pgtype.TextOID)
 	}
 	return
+}
+
+func (dst *MyCompositeRaw) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
+	a := pgtype.Int4{}
+	b := pgtype.Text{}
+
+	fieldIter, fieldCount, err := binary.NewRecordFieldIterator(src)
+	if err != nil {
+		return err
+	}
+
+	if 2 != fieldCount {
+		return errors.Errorf("can't scan row value, number of fields don't match: found=%d expected=2", fieldCount)
+	}
+
+	_, fieldBytes, eof, err := fieldIter.Next()
+	if eof || err != nil {
+		return errors.New("Bad record")
+	}
+	if err = a.DecodeBinary(ci, fieldBytes); err != nil {
+		return err
+	}
+
+	_, fieldBytes, eof, err = fieldIter.Next()
+	if eof || err != nil {
+		return errors.New("Bad record")
+	}
+	if err = b.DecodeBinary(ci, fieldBytes); err != nil {
+		return err
+	}
+
+	dst.a = a.Int
+	if b.Status == pgtype.Present {
+		dst.b = &b.String
+	} else {
+		dst.b = nil
+	}
+
+	return nil
 }
 
 var x []byte
@@ -69,4 +109,53 @@ func BenchmarkBinaryEncodingRow(b *testing.B) {
 		buf, _ = c.EncodeBinary(ci, buf[:0])
 	}
 	x = buf
+}
+
+var dstRaw MyCompositeRaw
+
+func BenchmarkBinaryDecodingManual(b *testing.B) {
+	ci := pgtype.NewConnInfo()
+	buf, _ := MyType{4, ptrS("ABCDEFG")}.EncodeBinary(ci, nil)
+	dst := MyCompositeRaw{}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err := dst.DecodeBinary(ci, buf)
+		E(err)
+	}
+	dstRaw = dst
+}
+
+var dstMyType MyType
+
+func BenchmarkBinaryDecodingHelpers(b *testing.B) {
+	ci := pgtype.NewConnInfo()
+	buf, _ := MyType{4, ptrS("ABCDEFG")}.EncodeBinary(ci, nil)
+	dst := MyType{}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err := dst.DecodeBinary(ci, buf)
+		E(err)
+	}
+	dstMyType = dst
+}
+
+var gf1 int
+var gf2 *string
+
+func BenchmarkBinaryDecodingRow(b *testing.B) {
+	ci := pgtype.NewConnInfo()
+	buf, _ := MyType{4, ptrS("ABCDEFG")}.EncodeBinary(ci, nil)
+	var isNull bool
+	var f1 int
+	var f2 *string
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err := pgtype.Row(&isNull, &f1, &f2).DecodeBinary(ci, buf)
+		E(err)
+	}
+	gf1 = f1
+	gf2 = f2
 }

--- a/composite_bench_test.go
+++ b/composite_bench_test.go
@@ -110,6 +110,18 @@ func BenchmarkBinaryEncodingRow(b *testing.B) {
 	}
 	x = buf
 }
+func BenchmarkBinaryEncodingRowInplace(b *testing.B) {
+	buf := make([]byte, 0, 128)
+	ci := pgtype.NewConnInfo()
+	f1 := 2
+	f2 := ptrS("bar")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		buf, _ = pgtype.Composite(&pgtype.Int4{}, &pgtype.Text{}).Row(f1, f2).EncodeBinary(ci, buf[:0])
+	}
+	x = buf
+}
 
 var dstRaw MyCompositeRaw
 

--- a/composite_bench_test.go
+++ b/composite_bench_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 type MyCompositeRaw struct {
-	a int32
-	b *string
+	A int32
+	B *string
 }
 
 func (src MyCompositeRaw) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) (newBuf []byte, err error) {
-	a := pgtype.Int4{src.a, pgtype.Present}
+	a := pgtype.Int4{src.A, pgtype.Present}
 
 	fieldBytes := make([]byte, 0, 64)
 	fieldBytes, _ = a.EncodeBinary(ci, fieldBytes[:0])
@@ -22,8 +22,8 @@ func (src MyCompositeRaw) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) (newBuf 
 	newBuf = binary.RecordStart(buf, 2)
 	newBuf = binary.RecordAdd(newBuf, pgtype.Int4OID, fieldBytes)
 
-	if src.b != nil {
-		fieldBytes, _ = pgtype.Text{*src.b, pgtype.Present}.EncodeBinary(ci, fieldBytes[:0])
+	if src.B != nil {
+		fieldBytes, _ = pgtype.Text{*src.B, pgtype.Present}.EncodeBinary(ci, fieldBytes[:0])
 		newBuf = binary.RecordAdd(newBuf, pgtype.TextOID, fieldBytes)
 	} else {
 		newBuf = binary.RecordAddNull(newBuf, pgtype.TextOID)
@@ -60,11 +60,11 @@ func (dst *MyCompositeRaw) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
 		return err
 	}
 
-	dst.a = a.Int
+	dst.A = a.Int
 	if b.Status == pgtype.Present {
-		dst.b = &b.String
+		dst.B = &b.String
 	} else {
-		dst.b = nil
+		dst.B = nil
 	}
 
 	return nil
@@ -96,7 +96,7 @@ func BenchmarkBinaryEncodingHelper(b *testing.B) {
 	x = buf
 }
 
-func BenchmarkBinaryEncodingRow(b *testing.B) {
+func BenchmarkBinaryEncodingComposite(b *testing.B) {
 	buf := make([]byte, 0, 128)
 	ci := pgtype.NewConnInfo()
 	f1 := 2
@@ -107,6 +107,20 @@ func BenchmarkBinaryEncodingRow(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		c.SetFields(f1, f2)
 		buf, _ = c.EncodeBinary(ci, buf[:0])
+	}
+	x = buf
+}
+
+func BenchmarkBinaryEncodingJSON(b *testing.B) {
+	buf := make([]byte, 0, 128)
+	ci := pgtype.NewConnInfo()
+	v := MyCompositeRaw{4, ptrS("ABCDEFG")}
+	j := pgtype.JSON{}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		j.Set(v)
+		buf, _ = j.EncodeBinary(ci, buf[:0])
 	}
 	x = buf
 }
@@ -160,4 +174,23 @@ func BenchmarkBinaryDecodingCompositeScan(b *testing.B) {
 	}
 	gf1 = f1
 	gf2 = f2
+}
+
+func BenchmarkBinaryDecodingJSON(b *testing.B) {
+	ci := pgtype.NewConnInfo()
+	j := pgtype.JSON{}
+	j.Set(MyCompositeRaw{4, ptrS("ABCDEFG")})
+	buf, _ := j.EncodeBinary(ci, nil)
+
+	j = pgtype.JSON{}
+	dst := MyCompositeRaw{}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err := j.DecodeBinary(ci, buf)
+		E(err)
+		err = j.AssignTo(&dst)
+		E(err)
+	}
+	dstRaw = dst
 }

--- a/composite_bench_test.go
+++ b/composite_bench_test.go
@@ -1,0 +1,70 @@
+package pgtype_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgtype"
+	"github.com/jackc/pgtype/binary"
+)
+
+type MyCompositeRaw struct {
+	a int32
+	b *string
+}
+
+func (src MyCompositeRaw) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) (newBuf []byte, err error) {
+	a := pgtype.Int4{src.a, pgtype.Present}
+
+	fieldBytes := make([]byte, 0, 64)
+	fieldBytes, _ = a.EncodeBinary(ci, fieldBytes[:0])
+
+	newBuf = binary.RecordStart(buf, 2)
+	newBuf = binary.RecordAdd(newBuf, pgtype.Int4OID, fieldBytes)
+
+	if src.b != nil {
+		fieldBytes, _ = pgtype.Text{*src.b, pgtype.Present}.EncodeBinary(ci, fieldBytes[:0])
+		newBuf = binary.RecordAdd(newBuf, pgtype.TextOID, fieldBytes)
+	} else {
+		newBuf = binary.RecordAddNull(newBuf, pgtype.TextOID)
+	}
+	return
+}
+
+var x []byte
+
+func BenchmarkBinaryEncodingManual(b *testing.B) {
+	buf := make([]byte, 0, 128)
+	ci := pgtype.NewConnInfo()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		v := MyCompositeRaw{4, ptrS("ABCDEFG")}
+		buf, _ = v.EncodeBinary(ci, buf[:0])
+	}
+	x = buf
+}
+
+func BenchmarkBinaryEncodingHelper(b *testing.B) {
+	buf := make([]byte, 0, 128)
+	ci := pgtype.NewConnInfo()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		v := MyType{4, ptrS("ABCDEFG")}
+		buf, _ = v.EncodeBinary(ci, buf[:0])
+	}
+	x = buf
+}
+
+func BenchmarkBinaryEncodingRow(b *testing.B) {
+	buf := make([]byte, 0, 128)
+	ci := pgtype.NewConnInfo()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c := pgtype.Composite(&pgtype.Int4{}, &pgtype.Text{})
+		c.Set(pgtype.Row(2, "bar"))
+		buf, _ = c.EncodeBinary(ci, buf[:0])
+	}
+	x = buf
+}

--- a/composite_bench_test.go
+++ b/composite_bench_test.go
@@ -35,10 +35,10 @@ var x []byte
 func BenchmarkBinaryEncodingManual(b *testing.B) {
 	buf := make([]byte, 0, 128)
 	ci := pgtype.NewConnInfo()
+	v := MyCompositeRaw{4, ptrS("ABCDEFG")}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		v := MyCompositeRaw{4, ptrS("ABCDEFG")}
 		buf, _ = v.EncodeBinary(ci, buf[:0])
 	}
 	x = buf
@@ -47,10 +47,10 @@ func BenchmarkBinaryEncodingManual(b *testing.B) {
 func BenchmarkBinaryEncodingHelper(b *testing.B) {
 	buf := make([]byte, 0, 128)
 	ci := pgtype.NewConnInfo()
+	v := MyType{4, ptrS("ABCDEFG")}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		v := MyType{4, ptrS("ABCDEFG")}
 		buf, _ = v.EncodeBinary(ci, buf[:0])
 	}
 	x = buf
@@ -59,11 +59,13 @@ func BenchmarkBinaryEncodingHelper(b *testing.B) {
 func BenchmarkBinaryEncodingRow(b *testing.B) {
 	buf := make([]byte, 0, 128)
 	ci := pgtype.NewConnInfo()
+	f1 := 2
+	f2 := ptrS("bar")
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		c := pgtype.Composite(&pgtype.Int4{}, &pgtype.Text{})
-		c.Set(pgtype.Row(2, "bar"))
+		c.Set(pgtype.Row(f1, f2))
 		buf, _ = c.EncodeBinary(ci, buf[:0])
 	}
 	x = buf

--- a/composite_test.go
+++ b/composite_test.go
@@ -1,0 +1,77 @@
+package pgtype_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgtype"
+	pgx "github.com/jackc/pgx/v4"
+	errors "golang.org/x/xerrors"
+)
+
+type MyType struct {
+	a int32   // NULL will cause decoding error
+	b *string // there can be NULL in this position in SQL
+}
+
+func (dst *MyType) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
+	if src == nil {
+		return errors.New("NULL values can't be decoded. Scan into a &*MyType to handle NULLs")
+	}
+
+	a := pgtype.Int4{}
+	b := pgtype.Text{}
+
+	if err := pgtype.ScanRowValue(ci, src, &a, &b); err != nil {
+		return err
+	}
+
+	// type compatibility is checked by AssignTo
+	// only lossless assignments will succeed
+	if err := a.AssignTo(&dst.a); err != nil {
+		return err
+	}
+
+	// AssignTo also deals with null value handling
+	if err := b.AssignTo(&dst.b); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Example_compositeTypes() {
+	conn, err := pgx.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close(context.Background())
+	_, err = conn.Exec(context.Background(), `drop type if exists mytype;
+
+create type mytype as (
+  a int4,
+  b text
+);`)
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Exec(context.Background(), "drop type mytype")
+
+	var result *MyType
+	if err = conn.QueryRow(context.Background(), "select (1,'foo')::mytype", pgx.QueryResultFormats{pgx.BinaryFormatCode}).Scan(&result); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("First row: a=%d b=%s\n", result.a, *result.b)
+
+	// Because we scan into &*MyType, NULLs are handled generically by assigning nil to result
+	if err = conn.QueryRow(context.Background(), "select NULL::mytype", pgx.QueryResultFormats{pgx.BinaryFormatCode}).Scan(&result); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Second row: %v\n", result)
+	// Output:
+	// First row: a=1 b=foo
+	// Second row: <nil>
+}

--- a/composite_test.go
+++ b/composite_test.go
@@ -71,7 +71,20 @@ create type mytype as (
 	}
 
 	fmt.Printf("Second row: %v\n", result)
+
+	// Adhoc rows can be decoded inplace without boilerplate (works with composite types too)
+	var isNull bool
+	var a int
+	var b *string
+
+	if err = conn.QueryRow(context.Background(), "select (2, 'bar')::mytype", pgx.QueryResultFormats{pgx.BinaryFormatCode}).Scan(pgtype.ROW(&isNull, &a, &b)); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Adhoc: isNull=%v a=%d b=%s", isNull, a, *b)
+
 	// Output:
 	// First row: a=1 b=foo
 	// Second row: <nil>
+	// Adhoc: isNull=false a=2 b=bar
 }

--- a/composite_test.go
+++ b/composite_test.go
@@ -25,6 +25,8 @@ create type mytype as (
 	E(err)
 	defer conn.Exec(context.Background(), "drop type mytype")
 
+	qrf := pgx.QueryResultFormats{pgx.BinaryFormatCode}
+
 	var isNull bool
 	var a int
 	var b *string
@@ -32,18 +34,18 @@ create type mytype as (
 	c := pgtype.NewComposite(&pgtype.Int4{}, &pgtype.Text{})
 	c.SetFields(2, "bar")
 
-	err = conn.QueryRow(context.Background(), "select $1::mytype", c).
+	err = conn.QueryRow(context.Background(), "select $1::mytype", qrf, c).
 		Scan(c.Scan(&isNull, &a, &b))
 	E(err)
 
 	fmt.Printf("First: isNull=%v a=%d b=%s\n", isNull, a, *b)
 
-	err = conn.QueryRow(context.Background(), "select (1, NULL)::mytype").Scan(c.Scan(&isNull, &a, &b))
+	err = conn.QueryRow(context.Background(), "select (1, NULL)::mytype", qrf).Scan(c.Scan(&isNull, &a, &b))
 	E(err)
 
 	fmt.Printf("Second: isNull=%v a=%d b=%v\n", isNull, a, b)
 
-	err = conn.QueryRow(context.Background(), "select NULL::mytype").Scan(c.Scan(&isNull, &a, &b))
+	err = conn.QueryRow(context.Background(), "select NULL::mytype", qrf).Scan(c.Scan(&isNull, &a, &b))
 	E(err)
 
 	fmt.Printf("Third: isNull=%v\n", isNull)

--- a/composite_test.go
+++ b/composite_test.go
@@ -7,63 +7,11 @@ import (
 
 	"github.com/jackc/pgtype"
 	pgx "github.com/jackc/pgx/v4"
-	errors "golang.org/x/xerrors"
 )
 
-type MyType struct {
-	a int32   // NULL will cause decoding error
-	b *string // there can be NULL in this position in SQL
-}
-
-func (dst *MyType) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
-	if src == nil {
-		return errors.New("NULL values can't be decoded. Scan into a &*MyType to handle NULLs")
-	}
-
-	a := pgtype.Int4{}
-	b := pgtype.Text{}
-
-	if err := pgtype.ScanRowValue(ci, src, &a, &b); err != nil {
-		return err
-	}
-
-	// type compatibility is checked by AssignTo
-	// only lossless assignments will succeed
-	if err := a.AssignTo(&dst.a); err != nil {
-		return err
-	}
-
-	// AssignTo also deals with null value handling
-	if err := b.AssignTo(&dst.b); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (src MyType) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) (newBuf []byte, err error) {
-	a := pgtype.Int4{src.a, pgtype.Present}
-	var b pgtype.Text
-	if src.b != nil {
-		b = pgtype.Text{*src.b, pgtype.Present}
-	} else {
-		b = pgtype.Text{Status: pgtype.Null}
-	}
-
-	return pgtype.EncodeRow(ci, buf, &a, &b)
-}
-
-func ptrS(s string) *string {
-	return &s
-}
-
-func E(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
-
-func Example_compositeTypes() {
+//ExampleComposite demonstrates use of Row() function to pass and receive
+// back composite types without creating boilderplate custom types.
+func Example_composite() {
 	conn, err := pgx.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
 	E(err)
 
@@ -77,43 +25,34 @@ create type mytype as (
 	E(err)
 	defer conn.Exec(context.Background(), "drop type mytype")
 
-	var result *MyType
-
-	// Demonstrates both passing and reading back composite values
-	err = conn.QueryRow(context.Background(), "select $1::mytype",
-		pgx.QueryResultFormats{pgx.BinaryFormatCode}, MyType{1, ptrS("foo")}).
-		Scan(&result)
-	E(err)
-
-	fmt.Printf("First row: a=%d b=%s\n", result.a, *result.b)
-
-	// Because we scan into &*MyType, NULLs are handled generically by assigning nil to result
-	err = conn.QueryRow(context.Background(), "select NULL::mytype", pgx.QueryResultFormats{pgx.BinaryFormatCode}).Scan(&result)
-	E(err)
-
-	fmt.Printf("Second row: %v\n", result)
-
 	//WIP
 	q, err := conn.Prepare(context.Background(), "z", "select $1::mytype")
 	E(err)
 	conn.ConnInfo().RegisterDataType(pgtype.DataType{pgtype.Composite(&pgtype.Int4{}, &pgtype.Text{}), "mytype", q.ParamOIDs[0]})
 
-	// Adhoc rows can be decoded inplace without boilerplate
-	// Composite types can be encoded/decoded inplace
-
 	var isNull bool
 	var a int
 	var b *string
 
-	err = conn.QueryRow(context.Background(), "select row(($1::mytype).a, ($1).b)",
-		pgx.QueryResultFormats{pgx.BinaryFormatCode}, pgtype.Row(2, "bar")).
+	err = conn.QueryRow(context.Background(), "select $1::mytype",
+		pgtype.Row(2, "bar")).
 		Scan(pgtype.Row(&isNull, &a, &b))
 	E(err)
 
-	fmt.Printf("Adhoc: isNull=%v a=%d b=%s", isNull, a, *b)
+	fmt.Printf("First: isNull=%v a=%d b=%s\n", isNull, a, *b)
+
+	err = conn.QueryRow(context.Background(), "select (1, NULL)::mytype").Scan(pgtype.Row(&isNull, &a, &b))
+	E(err)
+
+	fmt.Printf("Second: isNull=%v a=%d b=%v\n", isNull, a, b)
+
+	err = conn.QueryRow(context.Background(), "select NULL::mytype").Scan(pgtype.Row(&isNull, &a, &b))
+	E(err)
+
+	fmt.Printf("Third: isNull=%v\n", isNull)
 
 	// Output:
-	// First row: a=1 b=foo
-	// Second row: <nil>
-	// Adhoc: isNull=false a=2 b=bar
+	// First: isNull=false a=2 b=bar
+	// Second: isNull=false a=1 b=<nil>
+	// Third: isNull=true
 }

--- a/convert.go
+++ b/convert.go
@@ -449,7 +449,7 @@ func ScanRowValue(ci *ConnInfo, src []byte, dst ...BinaryDecoder) error {
 	}
 
 	if len(dst) != fieldCount {
-		return errors.Errorf("can't scan row value, number of fields don't match: row fields count=%d desired fields count=%d", fieldCount, len(dst))
+		return errors.Errorf("can't scan row value, number of fields don't match: found=%d expected=%d", fieldCount, len(dst))
 	}
 
 	_, fieldBytes, eof, err := fieldIter.Next()

--- a/convert.go
+++ b/convert.go
@@ -504,34 +504,6 @@ func EncodeRow(ci *ConnInfo, buf []byte, fields ...Value) (newBuf []byte, err er
 	return
 }
 
-// ROW allows deconstructing row values (records and composite types) into
-// fields directly without creating your own type and implementing decoder interfaces
-func ROW(isNull *bool, fields ...interface{}) BinaryDecoderFunc {
-	return func(ci *ConnInfo, src []byte) error {
-		var record Record
-		if err := record.DecodeBinary(ci, src); err != nil {
-			return err
-		}
-
-		if record.Status == Null {
-			*isNull = true
-			return nil
-		}
-
-		if len(record.Fields) != len(fields) {
-			return errors.Errorf("can't scan row value, number of fields don't match: row fields count=%d desired fields count=%d", len(record.Fields), len(fields))
-		}
-
-		for i, f := range record.Fields {
-			if err := f.AssignTo(fields[i]); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-}
-
 func init() {
 	kindTypes = map[reflect.Kind]reflect.Type{
 		reflect.Bool:    reflect.TypeOf(false),

--- a/custom_composite_test.go
+++ b/custom_composite_test.go
@@ -1,0 +1,101 @@
+package pgtype_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgtype"
+	pgx "github.com/jackc/pgx/v4"
+	errors "golang.org/x/xerrors"
+)
+
+type MyType struct {
+	a int32   // NULL will cause decoding error
+	b *string // there can be NULL in this position in SQL
+}
+
+func (dst *MyType) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
+	if src == nil {
+		return errors.New("NULL values can't be decoded. Scan into a &*MyType to handle NULLs")
+	}
+
+	a := pgtype.Int4{}
+	b := pgtype.Text{}
+
+	if err := pgtype.ScanRowValue(ci, src, &a, &b); err != nil {
+		return err
+	}
+
+	// type compatibility is checked by AssignTo
+	// only lossless assignments will succeed
+	if err := a.AssignTo(&dst.a); err != nil {
+		return err
+	}
+
+	// AssignTo also deals with null value handling
+	if err := b.AssignTo(&dst.b); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (src MyType) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) (newBuf []byte, err error) {
+	a := pgtype.Int4{src.a, pgtype.Present}
+	var b pgtype.Text
+	if src.b != nil {
+		b = pgtype.Text{*src.b, pgtype.Present}
+	} else {
+		b = pgtype.Text{Status: pgtype.Null}
+	}
+
+	return pgtype.EncodeRow(ci, buf, &a, &b)
+}
+
+func ptrS(s string) *string {
+	return &s
+}
+
+func E(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// ExampleCustomCompositeTypes demonstrates how support for custom types mappable to SQL
+// composites can be added.
+func Example_customCompositeTypes() {
+	conn, err := pgx.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	E(err)
+
+	defer conn.Close(context.Background())
+	_, err = conn.Exec(context.Background(), `drop type if exists mytype;
+
+create type mytype as (
+  a int4,
+  b text
+);`)
+	E(err)
+	defer conn.Exec(context.Background(), "drop type mytype")
+
+	var result *MyType
+
+	// Demonstrates both passing and reading back composite values
+	err = conn.QueryRow(context.Background(), "select $1::mytype",
+		pgx.QueryResultFormats{pgx.BinaryFormatCode}, MyType{1, ptrS("foo")}).
+		Scan(&result)
+	E(err)
+
+	fmt.Printf("First row: a=%d b=%s\n", result.a, *result.b)
+
+	// Because we scan into &*MyType, NULLs are handled generically by assigning nil to result
+	err = conn.QueryRow(context.Background(), "select NULL::mytype", pgx.QueryResultFormats{pgx.BinaryFormatCode}).Scan(&result)
+	E(err)
+
+	fmt.Printf("Second row: %v\n", result)
+
+	// Output:
+	// First row: a=1 b=foo
+	// Second row: <nil>
+}

--- a/pgtype.go
+++ b/pgtype.go
@@ -167,6 +167,15 @@ func (f BinaryDecoderFunc) DecodeBinary(ci *ConnInfo, src []byte) error {
 	return f(ci, src)
 }
 
+//The BinaryEncoderFunc type is an adapter to allow the use of ordinary functions as BinaryDecoder types.
+// If f is a function with the appropriate signature, BinaryEncoderFunc(f) is a BinaryDecoder that calls f.
+type BinaryEncoderFunc func(ci *ConnInfo, buf []byte) ([]byte, error)
+
+// EncodeBinary calls f(ci, buf)
+func (f BinaryEncoderFunc) EncodeBinary(ci *ConnInfo, buf []byte) (newBuf []byte, err error) {
+	return f(ci, buf)
+}
+
 var errUndefined = errors.New("cannot encode status undefined")
 var errBadStatus = errors.New("invalid status")
 

--- a/pgtype.go
+++ b/pgtype.go
@@ -158,6 +158,15 @@ type TextEncoder interface {
 	EncodeText(ci *ConnInfo, buf []byte) (newBuf []byte, err error)
 }
 
+//The BinaryDecoderFunc type is an adapter to allow the use of ordinary functions as BinaryDecoder types.
+// If f is a function with the appropriate signature, BinaryDecoderFunc(f) is a BinaryDecoder that calls f.
+type BinaryDecoderFunc func(ci *ConnInfo, src []byte) error
+
+// DecodeBinary calls f(ci, src)
+func (f BinaryDecoderFunc) DecodeBinary(ci *ConnInfo, src []byte) error {
+	return f(ci, src)
+}
+
 var errUndefined = errors.New("cannot encode status undefined")
 var errBadStatus = errors.New("invalid status")
 

--- a/record_test.go
+++ b/record_test.go
@@ -93,7 +93,10 @@ func TestScanRowValue(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Run(tt.sql, func(t *testing.T) {
-			desc := append([]pgtype.Value(nil), tt.expected.Fields...)
+			desc := []pgtype.BinaryDecoder{}
+			for _, f := range tt.expected.Fields {
+				desc = append(desc, f.(pgtype.BinaryDecoder))
+			}
 
 			var raw pgtype.GenericBinary
 
@@ -113,7 +116,10 @@ func TestScanRowValue(t *testing.T) {
 			}
 
 			// borrow fields from a neighbor test, this makes scan always fail
-			desc = append([]pgtype.Value(nil), recordTests[(i+1)%len(recordTests)].expected.Fields...)
+			desc = desc[:0]
+			for _, f := range recordTests[(i+1)%len(recordTests)].expected.Fields {
+				desc = append(desc, f.(pgtype.BinaryDecoder))
+			}
 			if err := pgtype.ScanRowValue(conn.ConnInfo(), raw.Bytes, desc...); err == nil {
 				t.Error("Matching scan didn't fail, despite fields not mathching query result")
 			}


### PR DESCRIPTION
This PR adds helpers to implement support of composite types.

Design goals of this PR are:
- spare users from knowing details of binary protocol, understanding oids, etc.
- natively support user types and values as if they were native types, no need to declare new wrapper types
- convenience at the call site
- minimize reflections and allocations achieving performance close to hand written binary decoders/encoders

2 main cases are covered: when user already has a type mapable to composite type in SQL and when composite values are built/scanned in adhoc way inplace using individual fields.

Provided helpers expect user to know upfront, which postgres types  their composite type is made of, there is no guessing or magical inference. 

# Custom types
There is a godoc example with MyType user struct mappable to SQL composite

https://github.com/jackc/pgtype/blob/04ff904ff59c7cdbb8bd3b7189c1b90bc02d3958/custom_composite_test.go#L13-L16

User doesn't need to create wrapper types to be able to pass their own types to SQL as parameters and read values back, it is sufficient to implement `BinaryEncoder` and `BinaryDecoder` interfaces. 

This PR adds helper functions `EncodeRow` and `ScanRowValue` to implement them without writing codec by hand. User first  maps their type to one or more pgtype.Value representing SQL composite fields and then calls EncodeRow/ScanRowValue to encode/decode these `pgtype.Value`s into/from SQL composite binary representation.

## EncodeRow

This is a helper to implement `BinaryEncode` method to satisfy `BinaryEncoder` interface. Once implemented user can pass their type values as SQL arguments.

https://github.com/jackc/pgtype/blob/04ff904ff59c7cdbb8bd3b7189c1b90bc02d3958/convert.go#L471-L472

EncodeRow takes initialized `pgtype.Value`s and encodes them into a single value of composite type, each one representing a composite value.  Return type is same as `BinaryEncode` return value. 

Intended use is to implement `BinaryEncode` method on user's custom types. Use is fairly straightforward:
- initialize `pgtype.Value` for each field of a composite
- pass initialized value to `EncodeRow` and return it's result.

In simple cases, where type can have no NULL fields it can be as simple as:
```go
func (src T) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) ([]byte, error) {
    return pgtype.EncodeRow(ci, buf, 
        pgtype.Int4{4, pgtype.Present},
        pgtype.Text{"abc", pgtype.Present}
    )
}
``` 

Example of more complicated case, where user type supports NULL values can be seen in provided godoc example _CustomCompositeTypes_.

## ScanRowValue

This is a helper to implement `BinaryDecode` method to satisfy `BinaryDecoder` interface. Once implemented user can read SQL query results into custom type.

https://github.com/jackc/pgtype/blob/04ff904ff59c7cdbb8bd3b7189c1b90bc02d3958/convert.go#L437-L445

When implementing BinaryDecode use ScanRowValue as following:
 - create pgtype.Value variables on per composite field
 - call `ScanRowValue` passing values in the order they go in composite field
 - values stored in  pgtype.Value can be inspected and  assigned to custom type fields. Easiest option is to use `AssignTo` on each value

One design consideration, when implementing `ScanRowValue` was whether it should use known oids from composite type binary representation instread of asking user to pass them explicitly. I decided against implicit behavior because:
- I want to be able to have arbitrary rules how to map Value to custom type fields. For instance one value can be split into 2 custom type fields, or additional processing can be made on a value. For this to work we need to work with concrete types, not just opaque Value interfaces
- Keep symmetry with `EncodeRow` - both operate on concrete types instantiated by user.
- Avoid unnecessary reflection. User is already aware of how their type is "made of", so avoiding user to specify types in on method buys nothing.
  
Example use of ScanRowValue can be found in godoc example _CustomCompositeTypes_.

# Adhoc composites

Sometimes user has no type yet available to be mapped to composite. To avoid creating otherwise unnecessary types, this PR adds helpers for working with composite field-wise.

It is implemented using Composite type, which acts as a "schema" for composite value.

Example use is in godoc example `Composite`.

## Composite.Scan

Passing result of Composite.Scan to a query Scan method acts like a destructuring assignment, where each fields of a compsite gives it's value to a corresponding argument of a Composite.Scan method. 