### PR TITLE
optimise struct padding

### DIFF
--- a/array_type.go
+++ b/array_type.go
@@ -15,11 +15,12 @@ import (
 type ArrayType struct {
 	elements   []ValueTranscoder
 	dimensions []ArrayDimension
-	status     Status
 
 	typeName   string
-	elementOID uint32
 	newElement func() ValueTranscoder
+
+	elementOID uint32
+	status     Status
 }
 
 func NewArrayType(typeName string, elementOID uint32, newElement func() ValueTranscoder) *ArrayType {


### PR DESCRIPTION
Reduce struct memory footprint and thus increase performance a bit.  

Proof: 
```go
package main

import (
	"fmt"
	"unsafe"

	"github.com/jackc/pgtype"
)

type old struct {
	elements   []pgtype.ValueTranscoder
	dimensions []pgtype.ArrayDimension
	status     pgtype.Status

	typeName   string
	elementOID uint32
	newElement func() pgtype.ValueTranscoder
}

type new struct {
	status     pgtype.Status
	elementOID uint32

	elements   []pgtype.ValueTranscoder
	dimensions []pgtype.ArrayDimension

	typeName   string
	newElement func() pgtype.ValueTranscoder
}

func main() {
	fmt.Println(unsafe.Sizeof(old{}))
	fmt.Println(unsafe.Sizeof(new{}))
}
```