### PR TITLE
Fix encoding of a large composite data type

### DIFF
--- a/composite_type.go
+++ b/composite_type.go
@@ -576,7 +576,7 @@ func (b *CompositeBinaryBuilder) AppendEncoder(oid uint32, field BinaryEncoder) 
 		return
 	}
 	if fieldBuf != nil {
-		binary.BigEndian.PutUint32(b.buf[lengthPos:], uint32(len(fieldBuf)-len(b.buf)))
+		binary.BigEndian.PutUint32(fieldBuf[lengthPos:], uint32(len(fieldBuf)-len(b.buf)))
 		b.buf = fieldBuf
 	}
 


### PR DESCRIPTION
If encoding a field caused a buffer reallocation, its length would be
written to a wrong place.