### PR TITLE
Add multidimensional array and slice support

### DIFF
--- a/aclitem_array.go
+++ b/aclitem_array.go
@@ -29,56 +29,110 @@ func (dst *ACLItemArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = ACLItemArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for ACLItemArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = ACLItemArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to ACLItemArray", src)
-	}
-
-	*dst = ACLItemArray{
-		Elements:   make([]ACLItem, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []string:
+		if value == nil {
+			*dst = ACLItemArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = ACLItemArray{Status: Present}
+		} else {
+			elements := make([]ACLItem, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]ACLItem, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = ACLItemArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*string:
+		if value == nil {
+			*dst = ACLItemArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = ACLItemArray{Status: Present}
+		} else {
+			elements := make([]ACLItem, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = ACLItemArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []ACLItem:
+		if value == nil {
+			*dst = ACLItemArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = ACLItemArray{Status: Present}
+		} else {
+			*dst = ACLItemArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = ACLItemArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for ACLItemArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = ACLItemArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to ACLItemArray", src)
+		}
+
+		*dst = ACLItemArray{
+			Elements:   make([]ACLItem, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]ACLItem, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to ACLItemArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to ACLItemArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -93,10 +147,11 @@ func (dst *ACLItemArray) setRecursive(value reflect.Value, index, dimension int)
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -131,6 +186,30 @@ func (dst ACLItemArray) Get() interface{} {
 func (src *ACLItemArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]string:
+				*v = make([]string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*string:
+				*v = make([]*string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -169,10 +248,12 @@ func (src *ACLItemArray) assignToRecursive(value reflect.Value, index, dimension
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -190,11 +271,14 @@ func (src *ACLItemArray) assignToRecursive(value reflect.Value, index, dimension
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from ACLItemArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from ACLItemArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/aclitem_array.go
+++ b/aclitem_array.go
@@ -4,6 +4,7 @@ package pgtype
 
 import (
 	"database/sql/driver"
+	"reflect"
 
 	errors "golang.org/x/xerrors"
 )
@@ -28,66 +29,92 @@ func (dst *ACLItemArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = ACLItemArray{Status: Null}
+		return nil
+	}
 
-	case []string:
-		if value == nil {
-			*dst = ACLItemArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = ACLItemArray{Status: Present}
-		} else {
-			elements := make([]ACLItem, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = ACLItemArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*string:
-		if value == nil {
-			*dst = ACLItemArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = ACLItemArray{Status: Present}
-		} else {
-			elements := make([]ACLItem, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = ACLItemArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []ACLItem:
-		if value == nil {
-			*dst = ACLItemArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = ACLItemArray{Status: Present}
-		} else {
-			*dst = ACLItemArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for ACLItemArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = ACLItemArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to ACLItemArray", value)
+		return errors.Errorf("cannot convert %v to ACLItemArray", src)
+	}
+
+	*dst = ACLItemArray{
+		Elements:   make([]ACLItem, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]ACLItem, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to ACLItemArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *ACLItemArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to ACLItemArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in ACLItemArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst ACLItemArray) Get() interface{} {
@@ -104,37 +131,74 @@ func (dst ACLItemArray) Get() interface{} {
 func (src *ACLItemArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]string:
-			*v = make([]string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*string:
-			*v = make([]*string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *ACLItemArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from ACLItemArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *ACLItemArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/aclitem_array_test.go
+++ b/aclitem_array_test.go
@@ -69,6 +69,74 @@ func TestACLItemArraySet(t *testing.T) {
 			source: (([]string)(nil)),
 			result: pgtype.ACLItemArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]string{{"=r/postgres"}, {"postgres=arwdDxt/postgres"}},
+			result: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]string{
+				{{{
+					"=r/postgres",
+					"postgres=arwdDxt/postgres",
+					"=r/postgres"}}},
+				{{{
+					"postgres=arwdDxt/postgres",
+					"=r/postgres",
+					"postgres=arwdDxt/postgres"}}}},
+			result: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present},
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present},
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]string{{"=r/postgres"}, {"postgres=arwdDxt/postgres"}},
+			result: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]string{
+				{{{
+					"=r/postgres",
+					"postgres=arwdDxt/postgres",
+					"=r/postgres"}}},
+				{{{
+					"postgres=arwdDxt/postgres",
+					"=r/postgres",
+					"postgres=arwdDxt/postgres"}}}},
+			result: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present},
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present},
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -88,6 +156,10 @@ func TestACLItemArrayAssignTo(t *testing.T) {
 	var stringSlice []string
 	type _stringSlice []string
 	var namedStringSlice _stringSlice
+	var stringSliceDim2 [][]string
+	var stringSliceDim4 [][][][]string
+	var stringArrayDim2 [2][1]string
+	var stringArrayDim4 [2][1][1][3]string
 
 	simpleTests := []struct {
 		src      pgtype.ACLItemArray
@@ -117,6 +189,78 @@ func TestACLItemArrayAssignTo(t *testing.T) {
 			dst:      &stringSlice,
 			expected: (([]string)(nil)),
 		},
+		{
+			src: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &stringSliceDim2,
+			expected: [][]string{{"=r/postgres"}, {"postgres=arwdDxt/postgres"}},
+		},
+		{
+			src: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present},
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present},
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &stringSliceDim4,
+			expected: [][][][]string{
+				{{{
+					"=r/postgres",
+					"postgres=arwdDxt/postgres",
+					"=r/postgres"}}},
+				{{{
+					"postgres=arwdDxt/postgres",
+					"=r/postgres",
+					"postgres=arwdDxt/postgres"}}}},
+		},
+		{
+			src: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &stringArrayDim2,
+			expected: [2][1]string{{"=r/postgres"}, {"postgres=arwdDxt/postgres"}},
+		},
+		{
+			src: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present},
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present},
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &stringArrayDim4,
+			expected: [2][1][1][3]string{
+				{{{
+					"=r/postgres",
+					"postgres=arwdDxt/postgres",
+					"=r/postgres"}}},
+				{{{
+					"postgres=arwdDxt/postgres",
+					"=r/postgres",
+					"postgres=arwdDxt/postgres"}}}},
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -141,6 +285,33 @@ func TestACLItemArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &stringSlice,
+		},
+		{
+			src: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &stringArrayDim2,
+		},
+		{
+			src: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &stringSlice,
+		},
+		{
+			src: pgtype.ACLItemArray{
+				Elements: []pgtype.ACLItem{
+					{String: "=r/postgres", Status: pgtype.Present},
+					{String: "postgres=arwdDxt/postgres", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &stringArrayDim4,
 		},
 	}
 

--- a/bool_array.go
+++ b/bool_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,66 +31,92 @@ func (dst *BoolArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = BoolArray{Status: Null}
+		return nil
+	}
 
-	case []bool:
-		if value == nil {
-			*dst = BoolArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = BoolArray{Status: Present}
-		} else {
-			elements := make([]Bool, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = BoolArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*bool:
-		if value == nil {
-			*dst = BoolArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = BoolArray{Status: Present}
-		} else {
-			elements := make([]Bool, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = BoolArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Bool:
-		if value == nil {
-			*dst = BoolArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = BoolArray{Status: Present}
-		} else {
-			*dst = BoolArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for BoolArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = BoolArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to BoolArray", value)
+		return errors.Errorf("cannot convert %v to BoolArray", src)
+	}
+
+	*dst = BoolArray{
+		Elements:   make([]Bool, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Bool, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to BoolArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *BoolArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to BoolArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in BoolArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst BoolArray) Get() interface{} {
@@ -106,37 +133,74 @@ func (dst BoolArray) Get() interface{} {
 func (src *BoolArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]bool:
-			*v = make([]bool, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*bool:
-			*v = make([]*bool, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *BoolArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from BoolArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *BoolArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/bool_array.go
+++ b/bool_array.go
@@ -31,6 +31,7 @@ func (dst *BoolArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []bool:
@@ -84,6 +85,9 @@ func (dst *BoolArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = BoolArray{Status: Null}
@@ -189,6 +193,7 @@ func (src *BoolArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]bool:
@@ -212,6 +217,9 @@ func (src *BoolArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -251,9 +259,8 @@ func (src *BoolArray) assignToRecursive(value reflect.Value, index, dimension in
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/bool_array.go
+++ b/bool_array.go
@@ -31,56 +31,110 @@ func (dst *BoolArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = BoolArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for BoolArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = BoolArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to BoolArray", src)
-	}
-
-	*dst = BoolArray{
-		Elements:   make([]Bool, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []bool:
+		if value == nil {
+			*dst = BoolArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = BoolArray{Status: Present}
+		} else {
+			elements := make([]Bool, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Bool, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = BoolArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*bool:
+		if value == nil {
+			*dst = BoolArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = BoolArray{Status: Present}
+		} else {
+			elements := make([]Bool, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = BoolArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Bool:
+		if value == nil {
+			*dst = BoolArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = BoolArray{Status: Present}
+		} else {
+			*dst = BoolArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = BoolArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for BoolArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = BoolArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to BoolArray", src)
+		}
+
+		*dst = BoolArray{
+			Elements:   make([]Bool, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Bool, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to BoolArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to BoolArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +149,11 @@ func (dst *BoolArray) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +188,30 @@ func (dst BoolArray) Get() interface{} {
 func (src *BoolArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]bool:
+				*v = make([]bool, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*bool:
+				*v = make([]*bool, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +250,12 @@ func (src *BoolArray) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +273,14 @@ func (src *BoolArray) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from BoolArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from BoolArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/bool_array_test.go
+++ b/bool_array_test.go
@@ -68,6 +68,54 @@ func TestBoolArraySet(t *testing.T) {
 			source: (([]bool)(nil)),
 			result: pgtype.BoolArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]bool{{true}, {false}},
+			result: pgtype.BoolArray{
+				Elements:   []pgtype.Bool{{Bool: true, Status: pgtype.Present}, {Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]bool{{{{true, false, true}}}, {{{false, true, false}}}},
+			result: pgtype.BoolArray{
+				Elements: []pgtype.Bool{
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present},
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present},
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]bool{{true}, {false}},
+			result: pgtype.BoolArray{
+				Elements:   []pgtype.Bool{{Bool: true, Status: pgtype.Present}, {Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]bool{{{{true, false, true}}}, {{{false, true, false}}}},
+			result: pgtype.BoolArray{
+				Elements: []pgtype.Bool{
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present},
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present},
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -87,6 +135,10 @@ func TestBoolArrayAssignTo(t *testing.T) {
 	var boolSlice []bool
 	type _boolSlice []bool
 	var namedBoolSlice _boolSlice
+	var boolSliceDim2 [][]bool
+	var boolSliceDim4 [][][][]bool
+	var boolArrayDim2 [2][1]bool
+	var boolArrayDim4 [2][1][1][3]bool
 
 	simpleTests := []struct {
 		src      pgtype.BoolArray
@@ -116,6 +168,58 @@ func TestBoolArrayAssignTo(t *testing.T) {
 			dst:      &boolSlice,
 			expected: (([]bool)(nil)),
 		},
+		{
+			src: pgtype.BoolArray{
+				Elements:   []pgtype.Bool{{Bool: true, Status: pgtype.Present}, {Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [][]bool{{true}, {false}},
+			dst:      &boolSliceDim2,
+		},
+		{
+			src: pgtype.BoolArray{
+				Elements: []pgtype.Bool{
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present},
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present},
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [][][][]bool{{{{true, false, true}}}, {{{false, true, false}}}},
+			dst:      &boolSliceDim4,
+		},
+		{
+			src: pgtype.BoolArray{
+				Elements:   []pgtype.Bool{{Bool: true, Status: pgtype.Present}, {Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [2][1]bool{{true}, {false}},
+			dst:      &boolArrayDim2,
+		},
+		{
+			src: pgtype.BoolArray{
+				Elements: []pgtype.Bool{
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present},
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present},
+					{Bool: true, Status: pgtype.Present},
+					{Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [2][1][1][3]bool{{{{true, false, true}}}, {{{false, true, false}}}},
+			dst:      &boolArrayDim4,
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -140,6 +244,27 @@ func TestBoolArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &boolSlice,
+		},
+		{
+			src: pgtype.BoolArray{
+				Elements:   []pgtype.Bool{{Bool: true, Status: pgtype.Present}, {Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &boolArrayDim2,
+		},
+		{
+			src: pgtype.BoolArray{
+				Elements:   []pgtype.Bool{{Bool: true, Status: pgtype.Present}, {Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &boolSlice,
+		},
+		{
+			src: pgtype.BoolArray{
+				Elements:   []pgtype.Bool{{Bool: true, Status: pgtype.Present}, {Bool: false, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &boolArrayDim4,
 		},
 	}
 

--- a/bpchar_array.go
+++ b/bpchar_array.go
@@ -31,6 +31,7 @@ func (dst *BPCharArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []string:
@@ -84,6 +85,9 @@ func (dst *BPCharArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = BPCharArray{Status: Null}
@@ -189,6 +193,7 @@ func (src *BPCharArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]string:
@@ -212,6 +217,9 @@ func (src *BPCharArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -251,9 +259,8 @@ func (src *BPCharArray) assignToRecursive(value reflect.Value, index, dimension 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/bpchar_array.go
+++ b/bpchar_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,66 +31,92 @@ func (dst *BPCharArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = BPCharArray{Status: Null}
+		return nil
+	}
 
-	case []string:
-		if value == nil {
-			*dst = BPCharArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = BPCharArray{Status: Present}
-		} else {
-			elements := make([]BPChar, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = BPCharArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*string:
-		if value == nil {
-			*dst = BPCharArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = BPCharArray{Status: Present}
-		} else {
-			elements := make([]BPChar, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = BPCharArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []BPChar:
-		if value == nil {
-			*dst = BPCharArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = BPCharArray{Status: Present}
-		} else {
-			*dst = BPCharArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for BPCharArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = BPCharArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to BPCharArray", value)
+		return errors.Errorf("cannot convert %v to BPCharArray", src)
+	}
+
+	*dst = BPCharArray{
+		Elements:   make([]BPChar, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]BPChar, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to BPCharArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *BPCharArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to BPCharArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in BPCharArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst BPCharArray) Get() interface{} {
@@ -106,37 +133,74 @@ func (dst BPCharArray) Get() interface{} {
 func (src *BPCharArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]string:
-			*v = make([]string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*string:
-			*v = make([]*string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *BPCharArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from BPCharArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *BPCharArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/bpchar_array.go
+++ b/bpchar_array.go
@@ -31,56 +31,110 @@ func (dst *BPCharArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = BPCharArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for BPCharArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = BPCharArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to BPCharArray", src)
-	}
-
-	*dst = BPCharArray{
-		Elements:   make([]BPChar, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []string:
+		if value == nil {
+			*dst = BPCharArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = BPCharArray{Status: Present}
+		} else {
+			elements := make([]BPChar, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]BPChar, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = BPCharArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*string:
+		if value == nil {
+			*dst = BPCharArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = BPCharArray{Status: Present}
+		} else {
+			elements := make([]BPChar, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = BPCharArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []BPChar:
+		if value == nil {
+			*dst = BPCharArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = BPCharArray{Status: Present}
+		} else {
+			*dst = BPCharArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = BPCharArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for BPCharArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = BPCharArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to BPCharArray", src)
+		}
+
+		*dst = BPCharArray{
+			Elements:   make([]BPChar, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]BPChar, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to BPCharArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to BPCharArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +149,11 @@ func (dst *BPCharArray) setRecursive(value reflect.Value, index, dimension int) 
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +188,30 @@ func (dst BPCharArray) Get() interface{} {
 func (src *BPCharArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]string:
+				*v = make([]string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*string:
+				*v = make([]*string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +250,12 @@ func (src *BPCharArray) assignToRecursive(value reflect.Value, index, dimension 
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +273,14 @@ func (src *BPCharArray) assignToRecursive(value reflect.Value, index, dimension 
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from BPCharArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from BPCharArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/bytea_array.go
+++ b/bytea_array.go
@@ -31,6 +31,7 @@ func (dst *ByteaArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case [][]byte:
@@ -65,6 +66,9 @@ func (dst *ByteaArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = ByteaArray{Status: Null}
@@ -170,6 +174,7 @@ func (src *ByteaArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[][]byte:
@@ -184,6 +189,9 @@ func (src *ByteaArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -223,9 +231,8 @@ func (src *ByteaArray) assignToRecursive(value reflect.Value, index, dimension i
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/bytea_array.go
+++ b/bytea_array.go
@@ -31,56 +31,91 @@ func (dst *ByteaArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = ByteaArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for ByteaArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = ByteaArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to ByteaArray", src)
-	}
-
-	*dst = ByteaArray{
-		Elements:   make([]Bytea, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case [][]byte:
+		if value == nil {
+			*dst = ByteaArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = ByteaArray{Status: Present}
+		} else {
+			elements := make([]Bytea, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Bytea, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = ByteaArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Bytea:
+		if value == nil {
+			*dst = ByteaArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = ByteaArray{Status: Present}
+		} else {
+			*dst = ByteaArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = ByteaArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for ByteaArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = ByteaArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to ByteaArray", src)
+		}
+
+		*dst = ByteaArray{
+			Elements:   make([]Bytea, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Bytea, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to ByteaArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to ByteaArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +130,11 @@ func (dst *ByteaArray) setRecursive(value reflect.Value, index, dimension int) (
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +169,21 @@ func (dst ByteaArray) Get() interface{} {
 func (src *ByteaArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[][]byte:
+				*v = make([][]byte, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +222,12 @@ func (src *ByteaArray) assignToRecursive(value reflect.Value, index, dimension i
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +245,14 @@ func (src *ByteaArray) assignToRecursive(value reflect.Value, index, dimension i
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from ByteaArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from ByteaArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/bytea_array.go
+++ b/bytea_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,47 +31,92 @@ func (dst *ByteaArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = ByteaArray{Status: Null}
+		return nil
+	}
 
-	case [][]byte:
-		if value == nil {
-			*dst = ByteaArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = ByteaArray{Status: Present}
-		} else {
-			elements := make([]Bytea, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = ByteaArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Bytea:
-		if value == nil {
-			*dst = ByteaArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = ByteaArray{Status: Present}
-		} else {
-			*dst = ByteaArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for ByteaArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = ByteaArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to ByteaArray", value)
+		return errors.Errorf("cannot convert %v to ByteaArray", src)
+	}
+
+	*dst = ByteaArray{
+		Elements:   make([]Bytea, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Bytea, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to ByteaArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *ByteaArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to ByteaArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in ByteaArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst ByteaArray) Get() interface{} {
@@ -87,28 +133,74 @@ func (dst ByteaArray) Get() interface{} {
 func (src *ByteaArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[][]byte:
-			*v = make([][]byte, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *ByteaArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from ByteaArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *ByteaArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/bytea_array_test.go
+++ b/bytea_array_test.go
@@ -68,6 +68,54 @@ func TestByteaArraySet(t *testing.T) {
 			source: (([][]byte)(nil)),
 			result: pgtype.ByteaArray{Status: pgtype.Null},
 		},
+		{
+			source: [][][]byte{{{1}}, {{2}}},
+			result: pgtype.ByteaArray{
+				Elements:   []pgtype.Bytea{{Bytes: []byte{1}, Status: pgtype.Present}, {Bytes: []byte{2}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][][]byte{{{{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}}}, {{{{10, 11, 12}, {13, 14, 15}, {16, 17, 18}}}}},
+			result: pgtype.ByteaArray{
+				Elements: []pgtype.Bytea{
+					{Bytes: []byte{1, 2, 3}, Status: pgtype.Present},
+					{Bytes: []byte{4, 5, 6}, Status: pgtype.Present},
+					{Bytes: []byte{7, 8, 9}, Status: pgtype.Present},
+					{Bytes: []byte{10, 11, 12}, Status: pgtype.Present},
+					{Bytes: []byte{13, 14, 15}, Status: pgtype.Present},
+					{Bytes: []byte{16, 17, 18}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1][]byte{{{1}}, {{2}}},
+			result: pgtype.ByteaArray{
+				Elements:   []pgtype.Bytea{{Bytes: []byte{1}, Status: pgtype.Present}, {Bytes: []byte{2}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3][]byte{{{{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}}}, {{{{10, 11, 12}, {13, 14, 15}, {16, 17, 18}}}}},
+			result: pgtype.ByteaArray{
+				Elements: []pgtype.Bytea{
+					{Bytes: []byte{1, 2, 3}, Status: pgtype.Present},
+					{Bytes: []byte{4, 5, 6}, Status: pgtype.Present},
+					{Bytes: []byte{7, 8, 9}, Status: pgtype.Present},
+					{Bytes: []byte{10, 11, 12}, Status: pgtype.Present},
+					{Bytes: []byte{13, 14, 15}, Status: pgtype.Present},
+					{Bytes: []byte{16, 17, 18}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -85,6 +133,10 @@ func TestByteaArraySet(t *testing.T) {
 
 func TestByteaArrayAssignTo(t *testing.T) {
 	var byteByteSlice [][]byte
+	var byteByteSliceDim2 [][][]byte
+	var byteByteSliceDim4 [][][][][]byte
+	var byteByteArraySliceDim2 [2][1][]byte
+	var byteByteArraySliceDim4 [2][1][1][3][]byte
 
 	simpleTests := []struct {
 		src      pgtype.ByteaArray
@@ -104,6 +156,58 @@ func TestByteaArrayAssignTo(t *testing.T) {
 			src:      pgtype.ByteaArray{Status: pgtype.Null},
 			dst:      &byteByteSlice,
 			expected: (([][]byte)(nil)),
+		},
+		{
+			src: pgtype.ByteaArray{
+				Elements:   []pgtype.Bytea{{Bytes: []byte{1}, Status: pgtype.Present}, {Bytes: []byte{2}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &byteByteSliceDim2,
+			expected: [][][]byte{{{1}}, {{2}}},
+		},
+		{
+			src: pgtype.ByteaArray{
+				Elements: []pgtype.Bytea{
+					{Bytes: []byte{1, 2, 3}, Status: pgtype.Present},
+					{Bytes: []byte{4, 5, 6}, Status: pgtype.Present},
+					{Bytes: []byte{7, 8, 9}, Status: pgtype.Present},
+					{Bytes: []byte{10, 11, 12}, Status: pgtype.Present},
+					{Bytes: []byte{13, 14, 15}, Status: pgtype.Present},
+					{Bytes: []byte{16, 17, 18}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &byteByteSliceDim4,
+			expected: [][][][][]byte{{{{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}}}, {{{{10, 11, 12}, {13, 14, 15}, {16, 17, 18}}}}},
+		},
+		{
+			src: pgtype.ByteaArray{
+				Elements:   []pgtype.Bytea{{Bytes: []byte{1}, Status: pgtype.Present}, {Bytes: []byte{2}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &byteByteArraySliceDim2,
+			expected: [2][1][]byte{{{1}}, {{2}}},
+		},
+		{
+			src: pgtype.ByteaArray{
+				Elements: []pgtype.Bytea{
+					{Bytes: []byte{1, 2, 3}, Status: pgtype.Present},
+					{Bytes: []byte{4, 5, 6}, Status: pgtype.Present},
+					{Bytes: []byte{7, 8, 9}, Status: pgtype.Present},
+					{Bytes: []byte{10, 11, 12}, Status: pgtype.Present},
+					{Bytes: []byte{13, 14, 15}, Status: pgtype.Present},
+					{Bytes: []byte{16, 17, 18}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &byteByteArraySliceDim4,
+			expected: [2][1][1][3][]byte{{{{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}}}, {{{{10, 11, 12}, {13, 14, 15}, {16, 17, 18}}}}},
 		},
 	}
 

--- a/cidr_array.go
+++ b/cidr_array.go
@@ -5,7 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
-	"net"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,85 +31,92 @@ func (dst *CIDRArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = CIDRArray{Status: Null}
+		return nil
+	}
 
-	case []*net.IPNet:
-		if value == nil {
-			*dst = CIDRArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = CIDRArray{Status: Present}
-		} else {
-			elements := make([]CIDR, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = CIDRArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []net.IP:
-		if value == nil {
-			*dst = CIDRArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = CIDRArray{Status: Present}
-		} else {
-			elements := make([]CIDR, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = CIDRArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*net.IP:
-		if value == nil {
-			*dst = CIDRArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = CIDRArray{Status: Present}
-		} else {
-			elements := make([]CIDR, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = CIDRArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []CIDR:
-		if value == nil {
-			*dst = CIDRArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = CIDRArray{Status: Present}
-		} else {
-			*dst = CIDRArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for CIDRArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = CIDRArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to CIDRArray", value)
+		return errors.Errorf("cannot convert %v to CIDRArray", src)
+	}
+
+	*dst = CIDRArray{
+		Elements:   make([]CIDR, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]CIDR, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to CIDRArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *CIDRArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to CIDRArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in CIDRArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst CIDRArray) Get() interface{} {
@@ -126,46 +133,74 @@ func (dst CIDRArray) Get() interface{} {
 func (src *CIDRArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]*net.IPNet:
-			*v = make([]*net.IPNet, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]net.IP:
-			*v = make([]net.IP, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*net.IP:
-			*v = make([]*net.IP, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *CIDRArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from CIDRArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *CIDRArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/cidr_array.go
+++ b/cidr_array.go
@@ -32,6 +32,7 @@ func (dst *CIDRArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []*net.IPNet:
@@ -104,6 +105,9 @@ func (dst *CIDRArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = CIDRArray{Status: Null}
@@ -209,6 +213,7 @@ func (src *CIDRArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]*net.IPNet:
@@ -241,6 +246,9 @@ func (src *CIDRArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -280,9 +288,8 @@ func (src *CIDRArray) assignToRecursive(value reflect.Value, index, dimension in
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/cidr_array.go
+++ b/cidr_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"net"
 	"reflect"
 
 	"github.com/jackc/pgio"
@@ -31,56 +32,129 @@ func (dst *CIDRArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = CIDRArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for CIDRArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = CIDRArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to CIDRArray", src)
-	}
-
-	*dst = CIDRArray{
-		Elements:   make([]CIDR, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []*net.IPNet:
+		if value == nil {
+			*dst = CIDRArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = CIDRArray{Status: Present}
+		} else {
+			elements := make([]CIDR, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]CIDR, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = CIDRArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []net.IP:
+		if value == nil {
+			*dst = CIDRArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = CIDRArray{Status: Present}
+		} else {
+			elements := make([]CIDR, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = CIDRArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*net.IP:
+		if value == nil {
+			*dst = CIDRArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = CIDRArray{Status: Present}
+		} else {
+			elements := make([]CIDR, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = CIDRArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []CIDR:
+		if value == nil {
+			*dst = CIDRArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = CIDRArray{Status: Present}
+		} else {
+			*dst = CIDRArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = CIDRArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for CIDRArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = CIDRArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to CIDRArray", src)
+		}
+
+		*dst = CIDRArray{
+			Elements:   make([]CIDR, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]CIDR, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to CIDRArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to CIDRArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +169,11 @@ func (dst *CIDRArray) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +208,39 @@ func (dst CIDRArray) Get() interface{} {
 func (src *CIDRArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]*net.IPNet:
+				*v = make([]*net.IPNet, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]net.IP:
+				*v = make([]net.IP, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*net.IP:
+				*v = make([]*net.IP, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +279,12 @@ func (src *CIDRArray) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +302,14 @@ func (src *CIDRArray) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from CIDRArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from CIDRArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/cidr_array_test.go
+++ b/cidr_array_test.go
@@ -80,6 +80,74 @@ func TestCIDRArraySet(t *testing.T) {
 			source: (([]net.IP)(nil)),
 			result: pgtype.CIDRArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]net.IP{{mustParseCIDR(t, "127.0.0.1/32").IP}, {mustParseCIDR(t, "10.0.0.1/32").IP}},
+			result: pgtype.CIDRArray{
+				Elements: []pgtype.CIDR{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/32"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]*net.IPNet{
+				{{{
+					mustParseCIDR(t, "127.0.0.1/24"),
+					mustParseCIDR(t, "10.0.0.1/24"),
+					mustParseCIDR(t, "172.16.0.1/16")}}},
+				{{{
+					mustParseCIDR(t, "192.168.0.1/16"),
+					mustParseCIDR(t, "224.0.0.1/24"),
+					mustParseCIDR(t, "169.168.0.1/16")}}}},
+			result: pgtype.CIDRArray{
+				Elements: []pgtype.CIDR{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "172.16.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "192.168.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "224.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "169.168.0.1/16"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]net.IP{{mustParseCIDR(t, "127.0.0.1/32").IP}, {mustParseCIDR(t, "10.0.0.1/32").IP}},
+			result: pgtype.CIDRArray{
+				Elements: []pgtype.CIDR{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/32"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]*net.IPNet{
+				{{{
+					mustParseCIDR(t, "127.0.0.1/24"),
+					mustParseCIDR(t, "10.0.0.1/24"),
+					mustParseCIDR(t, "172.16.0.1/16")}}},
+				{{{
+					mustParseCIDR(t, "192.168.0.1/16"),
+					mustParseCIDR(t, "224.0.0.1/24"),
+					mustParseCIDR(t, "169.168.0.1/16")}}}},
+			result: pgtype.CIDRArray{
+				Elements: []pgtype.CIDR{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "172.16.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "192.168.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "224.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "169.168.0.1/16"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -98,6 +166,10 @@ func TestCIDRArraySet(t *testing.T) {
 func TestCIDRArrayAssignTo(t *testing.T) {
 	var ipnetSlice []*net.IPNet
 	var ipSlice []net.IP
+	var ipSliceDim2 [][]net.IP
+	var ipnetSliceDim4 [][][][]*net.IPNet
+	var ipArrayDim2 [2][1]net.IP
+	var ipnetArrayDim4 [2][1][1][3]*net.IPNet
 
 	simpleTests := []struct {
 		src      pgtype.CIDRArray
@@ -149,6 +221,78 @@ func TestCIDRArrayAssignTo(t *testing.T) {
 			src:      pgtype.CIDRArray{Status: pgtype.Null},
 			dst:      &ipSlice,
 			expected: (([]net.IP)(nil)),
+		},
+		{
+			src: pgtype.CIDRArray{
+				Elements: []pgtype.CIDR{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/32"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &ipSliceDim2,
+			expected: [][]net.IP{{mustParseCIDR(t, "127.0.0.1/32").IP}, {mustParseCIDR(t, "10.0.0.1/32").IP}},
+		},
+		{
+			src: pgtype.CIDRArray{
+				Elements: []pgtype.CIDR{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "172.16.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "192.168.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "224.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "169.168.0.1/16"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &ipnetSliceDim4,
+			expected: [][][][]*net.IPNet{
+				{{{
+					mustParseCIDR(t, "127.0.0.1/24"),
+					mustParseCIDR(t, "10.0.0.1/24"),
+					mustParseCIDR(t, "172.16.0.1/16")}}},
+				{{{
+					mustParseCIDR(t, "192.168.0.1/16"),
+					mustParseCIDR(t, "224.0.0.1/24"),
+					mustParseCIDR(t, "169.168.0.1/16")}}}},
+		},
+		{
+			src: pgtype.CIDRArray{
+				Elements: []pgtype.CIDR{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/32"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &ipArrayDim2,
+			expected: [2][1]net.IP{{mustParseCIDR(t, "127.0.0.1/32").IP}, {mustParseCIDR(t, "10.0.0.1/32").IP}},
+		},
+		{
+			src: pgtype.CIDRArray{
+				Elements: []pgtype.CIDR{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "172.16.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "192.168.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "224.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "169.168.0.1/16"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &ipnetArrayDim4,
+			expected: [2][1][1][3]*net.IPNet{
+				{{{
+					mustParseCIDR(t, "127.0.0.1/24"),
+					mustParseCIDR(t, "10.0.0.1/24"),
+					mustParseCIDR(t, "172.16.0.1/16")}}},
+				{{{
+					mustParseCIDR(t, "192.168.0.1/16"),
+					mustParseCIDR(t, "224.0.0.1/24"),
+					mustParseCIDR(t, "169.168.0.1/16")}}}},
 		},
 	}
 

--- a/date_array.go
+++ b/date_array.go
@@ -5,7 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
-	"time"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,66 +31,92 @@ func (dst *DateArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = DateArray{Status: Null}
+		return nil
+	}
 
-	case []time.Time:
-		if value == nil {
-			*dst = DateArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = DateArray{Status: Present}
-		} else {
-			elements := make([]Date, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = DateArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*time.Time:
-		if value == nil {
-			*dst = DateArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = DateArray{Status: Present}
-		} else {
-			elements := make([]Date, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = DateArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Date:
-		if value == nil {
-			*dst = DateArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = DateArray{Status: Present}
-		} else {
-			*dst = DateArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for DateArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = DateArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to DateArray", value)
+		return errors.Errorf("cannot convert %v to DateArray", src)
+	}
+
+	*dst = DateArray{
+		Elements:   make([]Date, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Date, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to DateArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *DateArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to DateArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in DateArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst DateArray) Get() interface{} {
@@ -107,37 +133,74 @@ func (dst DateArray) Get() interface{} {
 func (src *DateArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]time.Time:
-			*v = make([]time.Time, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*time.Time:
-			*v = make([]*time.Time, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *DateArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from DateArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *DateArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/date_array.go
+++ b/date_array.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"reflect"
+	"time"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,56 +32,110 @@ func (dst *DateArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = DateArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for DateArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = DateArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to DateArray", src)
-	}
-
-	*dst = DateArray{
-		Elements:   make([]Date, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []time.Time:
+		if value == nil {
+			*dst = DateArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = DateArray{Status: Present}
+		} else {
+			elements := make([]Date, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Date, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = DateArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*time.Time:
+		if value == nil {
+			*dst = DateArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = DateArray{Status: Present}
+		} else {
+			elements := make([]Date, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = DateArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Date:
+		if value == nil {
+			*dst = DateArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = DateArray{Status: Present}
+		} else {
+			*dst = DateArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = DateArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for DateArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = DateArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to DateArray", src)
+		}
+
+		*dst = DateArray{
+			Elements:   make([]Date, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Date, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to DateArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to DateArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +150,11 @@ func (dst *DateArray) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +189,30 @@ func (dst DateArray) Get() interface{} {
 func (src *DateArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]time.Time:
+				*v = make([]time.Time, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*time.Time:
+				*v = make([]*time.Time, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +251,12 @@ func (src *DateArray) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +274,14 @@ func (src *DateArray) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from DateArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from DateArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/date_array_test.go
+++ b/date_array_test.go
@@ -69,6 +69,78 @@ func TestDateArraySet(t *testing.T) {
 			source: (([]time.Time)(nil)),
 			result: pgtype.DateArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+			result: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
+			result: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+			result: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
+			result: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -86,6 +158,10 @@ func TestDateArraySet(t *testing.T) {
 
 func TestDateArrayAssignTo(t *testing.T) {
 	var timeSlice []time.Time
+	var timeSliceDim2 [][]time.Time
+	var timeSliceDim4 [][][][]time.Time
+	var timeArrayDim2 [2][1]time.Time
+	var timeArrayDim4 [2][1][1][3]time.Time
 
 	simpleTests := []struct {
 		src      pgtype.DateArray
@@ -105,6 +181,82 @@ func TestDateArrayAssignTo(t *testing.T) {
 			src:      pgtype.DateArray{Status: pgtype.Null},
 			dst:      &timeSlice,
 			expected: (([]time.Time)(nil)),
+		},
+		{
+			src: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeSliceDim2,
+			expected: [][]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+		},
+		{
+			src: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &timeSliceDim4,
+			expected: [][][][]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
+		},
+		{
+			src: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim2,
+			expected: [2][1]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+		},
+		{
+			src: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &timeArrayDim4,
+			expected: [2][1][1][3]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
 		},
 	}
 
@@ -130,6 +282,33 @@ func TestDateArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &timeSlice,
+		},
+		{
+			src: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim2,
+		},
+		{
+			src: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &timeSlice,
+		},
+		{
+			src: pgtype.DateArray{
+				Elements: []pgtype.Date{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim4,
 		},
 	}
 

--- a/enum_array.go
+++ b/enum_array.go
@@ -4,6 +4,7 @@ package pgtype
 
 import (
 	"database/sql/driver"
+	"reflect"
 
 	errors "golang.org/x/xerrors"
 )
@@ -28,66 +29,92 @@ func (dst *EnumArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = EnumArray{Status: Null}
+		return nil
+	}
 
-	case []string:
-		if value == nil {
-			*dst = EnumArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = EnumArray{Status: Present}
-		} else {
-			elements := make([]GenericText, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = EnumArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*string:
-		if value == nil {
-			*dst = EnumArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = EnumArray{Status: Present}
-		} else {
-			elements := make([]GenericText, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = EnumArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []GenericText:
-		if value == nil {
-			*dst = EnumArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = EnumArray{Status: Present}
-		} else {
-			*dst = EnumArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for EnumArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = EnumArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to EnumArray", value)
+		return errors.Errorf("cannot convert %v to EnumArray", src)
+	}
+
+	*dst = EnumArray{
+		Elements:   make([]GenericText, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]GenericText, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to EnumArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *EnumArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to EnumArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in EnumArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst EnumArray) Get() interface{} {
@@ -104,37 +131,74 @@ func (dst EnumArray) Get() interface{} {
 func (src *EnumArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]string:
-			*v = make([]string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*string:
-			*v = make([]*string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *EnumArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from EnumArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *EnumArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/enum_array.go
+++ b/enum_array.go
@@ -29,6 +29,7 @@ func (dst *EnumArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []string:
@@ -82,6 +83,9 @@ func (dst *EnumArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = EnumArray{Status: Null}
@@ -187,6 +191,7 @@ func (src *EnumArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]string:
@@ -210,6 +215,9 @@ func (src *EnumArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -249,9 +257,8 @@ func (src *EnumArray) assignToRecursive(value reflect.Value, index, dimension in
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/enum_array_test.go
+++ b/enum_array_test.go
@@ -67,6 +67,54 @@ func TestEnumArrayArraySet(t *testing.T) {
 			source: (([]string)(nil)),
 			result: pgtype.EnumArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]string{{"foo"}, {"bar"}},
+			result: pgtype.EnumArray{
+				Elements:   []pgtype.GenericText{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+			result: pgtype.EnumArray{
+				Elements: []pgtype.GenericText{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]string{{"foo"}, {"bar"}},
+			result: pgtype.EnumArray{
+				Elements:   []pgtype.GenericText{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+			result: pgtype.EnumArray{
+				Elements: []pgtype.GenericText{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -86,6 +134,10 @@ func TestEnumArrayArrayAssignTo(t *testing.T) {
 	var stringSlice []string
 	type _stringSlice []string
 	var namedStringSlice _stringSlice
+	var stringSliceDim2 [][]string
+	var stringSliceDim4 [][][][]string
+	var stringArrayDim2 [2][1]string
+	var stringArrayDim4 [2][1][1][3]string
 
 	simpleTests := []struct {
 		src      pgtype.EnumArray
@@ -115,6 +167,58 @@ func TestEnumArrayArrayAssignTo(t *testing.T) {
 			dst:      &stringSlice,
 			expected: (([]string)(nil)),
 		},
+		{
+			src: pgtype.EnumArray{
+				Elements:   []pgtype.GenericText{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &stringSliceDim2,
+			expected: [][]string{{"foo"}, {"bar"}},
+		},
+		{
+			src: pgtype.EnumArray{
+				Elements: []pgtype.GenericText{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &stringSliceDim4,
+			expected: [][][][]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+		},
+		{
+			src: pgtype.EnumArray{
+				Elements:   []pgtype.GenericText{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &stringArrayDim2,
+			expected: [2][1]string{{"foo"}, {"bar"}},
+		},
+		{
+			src: pgtype.EnumArray{
+				Elements: []pgtype.GenericText{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &stringArrayDim4,
+			expected: [2][1][1][3]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -139,6 +243,27 @@ func TestEnumArrayArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &stringSlice,
+		},
+		{
+			src: pgtype.EnumArray{
+				Elements:   []pgtype.GenericText{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &stringArrayDim2,
+		},
+		{
+			src: pgtype.EnumArray{
+				Elements:   []pgtype.GenericText{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &stringSlice,
+		},
+		{
+			src: pgtype.EnumArray{
+				Elements:   []pgtype.GenericText{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &stringArrayDim4,
 		},
 	}
 

--- a/float4_array.go
+++ b/float4_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,66 +31,92 @@ func (dst *Float4Array) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = Float4Array{Status: Null}
+		return nil
+	}
 
-	case []float32:
-		if value == nil {
-			*dst = Float4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Float4Array{Status: Present}
-		} else {
-			elements := make([]Float4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Float4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*float32:
-		if value == nil {
-			*dst = Float4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Float4Array{Status: Present}
-		} else {
-			elements := make([]Float4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Float4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Float4:
-		if value == nil {
-			*dst = Float4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Float4Array{Status: Present}
-		} else {
-			*dst = Float4Array{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for Float4Array", src)
+	}
+	if elementsLength == 0 {
+		*dst = Float4Array{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to Float4Array", value)
+		return errors.Errorf("cannot convert %v to Float4Array", src)
+	}
+
+	*dst = Float4Array{
+		Elements:   make([]Float4, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Float4, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to Float4Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *Float4Array) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to Float4Array")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in Float4Array", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst Float4Array) Get() interface{} {
@@ -106,37 +133,74 @@ func (dst Float4Array) Get() interface{} {
 func (src *Float4Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]float32:
-			*v = make([]float32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*float32:
-			*v = make([]*float32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *Float4Array) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Float4Array")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *Float4Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/float4_array.go
+++ b/float4_array.go
@@ -31,6 +31,7 @@ func (dst *Float4Array) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []float32:
@@ -84,6 +85,9 @@ func (dst *Float4Array) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = Float4Array{Status: Null}
@@ -189,6 +193,7 @@ func (src *Float4Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]float32:
@@ -212,6 +217,9 @@ func (src *Float4Array) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -251,9 +259,8 @@ func (src *Float4Array) assignToRecursive(value reflect.Value, index, dimension 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/float4_array.go
+++ b/float4_array.go
@@ -31,56 +31,110 @@ func (dst *Float4Array) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = Float4Array{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for Float4Array", src)
-	}
-	if elementsLength == 0 {
-		*dst = Float4Array{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to Float4Array", src)
-	}
-
-	*dst = Float4Array{
-		Elements:   make([]Float4, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []float32:
+		if value == nil {
+			*dst = Float4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Float4Array{Status: Present}
+		} else {
+			elements := make([]Float4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Float4, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = Float4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*float32:
+		if value == nil {
+			*dst = Float4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Float4Array{Status: Present}
+		} else {
+			elements := make([]Float4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Float4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Float4:
+		if value == nil {
+			*dst = Float4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Float4Array{Status: Present}
+		} else {
+			*dst = Float4Array{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = Float4Array{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for Float4Array", src)
+		}
+		if elementsLength == 0 {
+			*dst = Float4Array{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to Float4Array", src)
+		}
+
+		*dst = Float4Array{
+			Elements:   make([]Float4, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Float4, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to Float4Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to Float4Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +149,11 @@ func (dst *Float4Array) setRecursive(value reflect.Value, index, dimension int) 
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +188,30 @@ func (dst Float4Array) Get() interface{} {
 func (src *Float4Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]float32:
+				*v = make([]float32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*float32:
+				*v = make([]*float32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +250,12 @@ func (src *Float4Array) assignToRecursive(value reflect.Value, index, dimension 
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +273,14 @@ func (src *Float4Array) assignToRecursive(value reflect.Value, index, dimension 
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from Float4Array")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Float4Array")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/float4_array_test.go
+++ b/float4_array_test.go
@@ -68,6 +68,54 @@ func TestFloat4ArraySet(t *testing.T) {
 			source: (([]float32)(nil)),
 			result: pgtype.Float4Array{Status: pgtype.Null},
 		},
+		{
+			source: [][]float32{{1}, {2}},
+			result: pgtype.Float4Array{
+				Elements:   []pgtype.Float4{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]float32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Float4Array{
+				Elements: []pgtype.Float4{
+					{Float: 1, Status: pgtype.Present},
+					{Float: 2, Status: pgtype.Present},
+					{Float: 3, Status: pgtype.Present},
+					{Float: 4, Status: pgtype.Present},
+					{Float: 5, Status: pgtype.Present},
+					{Float: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]float32{{1}, {2}},
+			result: pgtype.Float4Array{
+				Elements:   []pgtype.Float4{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]float32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Float4Array{
+				Elements: []pgtype.Float4{
+					{Float: 1, Status: pgtype.Present},
+					{Float: 2, Status: pgtype.Present},
+					{Float: 3, Status: pgtype.Present},
+					{Float: 4, Status: pgtype.Present},
+					{Float: 5, Status: pgtype.Present},
+					{Float: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -86,6 +134,10 @@ func TestFloat4ArraySet(t *testing.T) {
 func TestFloat4ArrayAssignTo(t *testing.T) {
 	var float32Slice []float32
 	var namedFloat32Slice _float32Slice
+	var float32SliceDim2 [][]float32
+	var float32SliceDim4 [][][][]float32
+	var float32ArrayDim2 [2][1]float32
+	var float32ArrayDim4 [2][1][1][3]float32
 
 	simpleTests := []struct {
 		src      pgtype.Float4Array
@@ -115,6 +167,58 @@ func TestFloat4ArrayAssignTo(t *testing.T) {
 			dst:      &float32Slice,
 			expected: (([]float32)(nil)),
 		},
+		{
+			src: pgtype.Float4Array{
+				Elements:   []pgtype.Float4{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [][]float32{{1}, {2}},
+			dst:      &float32SliceDim2,
+		},
+		{
+			src: pgtype.Float4Array{
+				Elements: []pgtype.Float4{
+					{Float: 1, Status: pgtype.Present},
+					{Float: 2, Status: pgtype.Present},
+					{Float: 3, Status: pgtype.Present},
+					{Float: 4, Status: pgtype.Present},
+					{Float: 5, Status: pgtype.Present},
+					{Float: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [][][][]float32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &float32SliceDim4,
+		},
+		{
+			src: pgtype.Float4Array{
+				Elements:   []pgtype.Float4{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [2][1]float32{{1}, {2}},
+			dst:      &float32ArrayDim2,
+		},
+		{
+			src: pgtype.Float4Array{
+				Elements: []pgtype.Float4{
+					{Float: 1, Status: pgtype.Present},
+					{Float: 2, Status: pgtype.Present},
+					{Float: 3, Status: pgtype.Present},
+					{Float: 4, Status: pgtype.Present},
+					{Float: 5, Status: pgtype.Present},
+					{Float: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [2][1][1][3]float32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &float32ArrayDim4,
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -139,6 +243,27 @@ func TestFloat4ArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &float32Slice,
+		},
+		{
+			src: pgtype.Float4Array{
+				Elements:   []pgtype.Float4{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &float32ArrayDim2,
+		},
+		{
+			src: pgtype.Float4Array{
+				Elements:   []pgtype.Float4{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &float32Slice,
+		},
+		{
+			src: pgtype.Float4Array{
+				Elements:   []pgtype.Float4{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &float32ArrayDim4,
 		},
 	}
 

--- a/float8_array.go
+++ b/float8_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,66 +31,92 @@ func (dst *Float8Array) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = Float8Array{Status: Null}
+		return nil
+	}
 
-	case []float64:
-		if value == nil {
-			*dst = Float8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Float8Array{Status: Present}
-		} else {
-			elements := make([]Float8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Float8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*float64:
-		if value == nil {
-			*dst = Float8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Float8Array{Status: Present}
-		} else {
-			elements := make([]Float8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Float8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Float8:
-		if value == nil {
-			*dst = Float8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Float8Array{Status: Present}
-		} else {
-			*dst = Float8Array{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for Float8Array", src)
+	}
+	if elementsLength == 0 {
+		*dst = Float8Array{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to Float8Array", value)
+		return errors.Errorf("cannot convert %v to Float8Array", src)
+	}
+
+	*dst = Float8Array{
+		Elements:   make([]Float8, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Float8, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to Float8Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *Float8Array) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to Float8Array")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in Float8Array", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst Float8Array) Get() interface{} {
@@ -106,37 +133,74 @@ func (dst Float8Array) Get() interface{} {
 func (src *Float8Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]float64:
-			*v = make([]float64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*float64:
-			*v = make([]*float64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *Float8Array) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Float8Array")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *Float8Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/float8_array.go
+++ b/float8_array.go
@@ -31,56 +31,110 @@ func (dst *Float8Array) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = Float8Array{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for Float8Array", src)
-	}
-	if elementsLength == 0 {
-		*dst = Float8Array{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to Float8Array", src)
-	}
-
-	*dst = Float8Array{
-		Elements:   make([]Float8, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []float64:
+		if value == nil {
+			*dst = Float8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Float8Array{Status: Present}
+		} else {
+			elements := make([]Float8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Float8, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = Float8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*float64:
+		if value == nil {
+			*dst = Float8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Float8Array{Status: Present}
+		} else {
+			elements := make([]Float8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Float8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Float8:
+		if value == nil {
+			*dst = Float8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Float8Array{Status: Present}
+		} else {
+			*dst = Float8Array{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = Float8Array{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for Float8Array", src)
+		}
+		if elementsLength == 0 {
+			*dst = Float8Array{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to Float8Array", src)
+		}
+
+		*dst = Float8Array{
+			Elements:   make([]Float8, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Float8, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to Float8Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to Float8Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +149,11 @@ func (dst *Float8Array) setRecursive(value reflect.Value, index, dimension int) 
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +188,30 @@ func (dst Float8Array) Get() interface{} {
 func (src *Float8Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]float64:
+				*v = make([]float64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*float64:
+				*v = make([]*float64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +250,12 @@ func (src *Float8Array) assignToRecursive(value reflect.Value, index, dimension 
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +273,14 @@ func (src *Float8Array) assignToRecursive(value reflect.Value, index, dimension 
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from Float8Array")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Float8Array")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/float8_array.go
+++ b/float8_array.go
@@ -31,6 +31,7 @@ func (dst *Float8Array) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []float64:
@@ -84,6 +85,9 @@ func (dst *Float8Array) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = Float8Array{Status: Null}
@@ -189,6 +193,7 @@ func (src *Float8Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]float64:
@@ -212,6 +217,9 @@ func (src *Float8Array) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -251,9 +259,8 @@ func (src *Float8Array) assignToRecursive(value reflect.Value, index, dimension 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/float8_array_test.go
+++ b/float8_array_test.go
@@ -68,6 +68,30 @@ func TestFloat8ArraySet(t *testing.T) {
 			source: (([]float64)(nil)),
 			result: pgtype.Float8Array{Status: pgtype.Null},
 		},
+		{
+			source: [][]float64{{1}, {2}},
+			result: pgtype.Float8Array{
+				Elements:   []pgtype.Float8{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]float64{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Float8Array{
+				Elements: []pgtype.Float8{
+					{Float: 1, Status: pgtype.Present},
+					{Float: 2, Status: pgtype.Present},
+					{Float: 3, Status: pgtype.Present},
+					{Float: 4, Status: pgtype.Present},
+					{Float: 5, Status: pgtype.Present},
+					{Float: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -86,6 +110,10 @@ func TestFloat8ArraySet(t *testing.T) {
 func TestFloat8ArrayAssignTo(t *testing.T) {
 	var float64Slice []float64
 	var namedFloat64Slice _float64Slice
+	var float64SliceDim2 [][]float64
+	var float64SliceDim4 [][][][]float64
+	var float64ArrayDim2 [2][1]float64
+	var float64ArrayDim4 [2][1][1][3]float64
 
 	simpleTests := []struct {
 		src      pgtype.Float8Array
@@ -115,6 +143,58 @@ func TestFloat8ArrayAssignTo(t *testing.T) {
 			dst:      &float64Slice,
 			expected: (([]float64)(nil)),
 		},
+		{
+			src: pgtype.Float8Array{
+				Elements:   []pgtype.Float8{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [][]float64{{1}, {2}},
+			dst:      &float64SliceDim2,
+		},
+		{
+			src: pgtype.Float8Array{
+				Elements: []pgtype.Float8{
+					{Float: 1, Status: pgtype.Present},
+					{Float: 2, Status: pgtype.Present},
+					{Float: 3, Status: pgtype.Present},
+					{Float: 4, Status: pgtype.Present},
+					{Float: 5, Status: pgtype.Present},
+					{Float: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [][][][]float64{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &float64SliceDim4,
+		},
+		{
+			src: pgtype.Float8Array{
+				Elements:   []pgtype.Float8{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [2][1]float64{{1}, {2}},
+			dst:      &float64ArrayDim2,
+		},
+		{
+			src: pgtype.Float8Array{
+				Elements: []pgtype.Float8{
+					{Float: 1, Status: pgtype.Present},
+					{Float: 2, Status: pgtype.Present},
+					{Float: 3, Status: pgtype.Present},
+					{Float: 4, Status: pgtype.Present},
+					{Float: 5, Status: pgtype.Present},
+					{Float: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [2][1][1][3]float64{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &float64ArrayDim4,
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -139,6 +219,27 @@ func TestFloat8ArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &float64Slice,
+		},
+		{
+			src: pgtype.Float8Array{
+				Elements:   []pgtype.Float8{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &float64ArrayDim2,
+		},
+		{
+			src: pgtype.Float8Array{
+				Elements:   []pgtype.Float8{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &float64Slice,
+		},
+		{
+			src: pgtype.Float8Array{
+				Elements:   []pgtype.Float8{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &float64ArrayDim4,
 		},
 	}
 

--- a/hstore_array.go
+++ b/hstore_array.go
@@ -31,56 +31,91 @@ func (dst *HstoreArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = HstoreArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for HstoreArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = HstoreArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to HstoreArray", src)
-	}
-
-	*dst = HstoreArray{
-		Elements:   make([]Hstore, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []map[string]string:
+		if value == nil {
+			*dst = HstoreArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = HstoreArray{Status: Present}
+		} else {
+			elements := make([]Hstore, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Hstore, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = HstoreArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Hstore:
+		if value == nil {
+			*dst = HstoreArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = HstoreArray{Status: Present}
+		} else {
+			*dst = HstoreArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = HstoreArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for HstoreArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = HstoreArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to HstoreArray", src)
+		}
+
+		*dst = HstoreArray{
+			Elements:   make([]Hstore, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Hstore, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to HstoreArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to HstoreArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +130,11 @@ func (dst *HstoreArray) setRecursive(value reflect.Value, index, dimension int) 
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +169,21 @@ func (dst HstoreArray) Get() interface{} {
 func (src *HstoreArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]map[string]string:
+				*v = make([]map[string]string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +222,12 @@ func (src *HstoreArray) assignToRecursive(value reflect.Value, index, dimension 
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +245,14 @@ func (src *HstoreArray) assignToRecursive(value reflect.Value, index, dimension 
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from HstoreArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from HstoreArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/hstore_array.go
+++ b/hstore_array.go
@@ -31,6 +31,7 @@ func (dst *HstoreArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []map[string]string:
@@ -65,6 +66,9 @@ func (dst *HstoreArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = HstoreArray{Status: Null}
@@ -170,6 +174,7 @@ func (src *HstoreArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]map[string]string:
@@ -184,6 +189,9 @@ func (src *HstoreArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -223,9 +231,8 @@ func (src *HstoreArray) assignToRecursive(value reflect.Value, index, dimension 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/hstore_array.go
+++ b/hstore_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,47 +31,92 @@ func (dst *HstoreArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = HstoreArray{Status: Null}
+		return nil
+	}
 
-	case []map[string]string:
-		if value == nil {
-			*dst = HstoreArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = HstoreArray{Status: Present}
-		} else {
-			elements := make([]Hstore, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = HstoreArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Hstore:
-		if value == nil {
-			*dst = HstoreArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = HstoreArray{Status: Present}
-		} else {
-			*dst = HstoreArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for HstoreArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = HstoreArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to HstoreArray", value)
+		return errors.Errorf("cannot convert %v to HstoreArray", src)
+	}
+
+	*dst = HstoreArray{
+		Elements:   make([]Hstore, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Hstore, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to HstoreArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *HstoreArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to HstoreArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in HstoreArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst HstoreArray) Get() interface{} {
@@ -87,28 +133,74 @@ func (dst HstoreArray) Get() interface{} {
 func (src *HstoreArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]map[string]string:
-			*v = make([]map[string]string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *HstoreArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from HstoreArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *HstoreArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/hstore_array_test.go
+++ b/hstore_array_test.go
@@ -131,7 +131,7 @@ func TestHstoreArrayTranscode(t *testing.T) {
 
 func TestHstoreArraySet(t *testing.T) {
 	successfulTests := []struct {
-		src    []map[string]string
+		src    interface{}
 		result pgtype.HstoreArray
 	}{
 		{
@@ -145,6 +145,118 @@ func TestHstoreArraySet(t *testing.T) {
 				},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}},
 				Status:     pgtype.Present,
+			},
+		},
+		{
+			src: [][]map[string]string{{{"foo": "bar"}}, {{"baz": "quz"}}},
+			result: pgtype.HstoreArray{
+				Elements: []pgtype.Hstore{
+					{
+						Map:    map[string]pgtype.Text{"foo": {String: "bar", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"baz": {String: "quz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+				},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present,
+			},
+		},
+		{
+			src: [][][][]map[string]string{
+				{{{{"foo": "bar"}, {"baz": "quz"}, {"bar": "baz"}}}},
+				{{{{"wibble": "wobble"}, {"wubble": "wabble"}, {"wabble": "wobble"}}}}},
+			result: pgtype.HstoreArray{
+				Elements: []pgtype.Hstore{
+					{
+						Map:    map[string]pgtype.Text{"foo": {String: "bar", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"baz": {String: "quz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"bar": {String: "baz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wibble": {String: "wobble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wubble": {String: "wabble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wabble": {String: "wobble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+				},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present,
+			},
+		},
+		{
+			src: [2][1]map[string]string{{{"foo": "bar"}}, {{"baz": "quz"}}},
+			result: pgtype.HstoreArray{
+				Elements: []pgtype.Hstore{
+					{
+						Map:    map[string]pgtype.Text{"foo": {String: "bar", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"baz": {String: "quz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+				},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present,
+			},
+		},
+		{
+			src: [2][1][1][3]map[string]string{
+				{{{{"foo": "bar"}, {"baz": "quz"}, {"bar": "baz"}}}},
+				{{{{"wibble": "wobble"}, {"wubble": "wabble"}, {"wabble": "wobble"}}}}},
+			result: pgtype.HstoreArray{
+				Elements: []pgtype.Hstore{
+					{
+						Map:    map[string]pgtype.Text{"foo": {String: "bar", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"baz": {String: "quz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"bar": {String: "baz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wibble": {String: "wobble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wubble": {String: "wabble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wabble": {String: "wobble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+				},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present,
 			},
 		},
 	}
@@ -163,12 +275,16 @@ func TestHstoreArraySet(t *testing.T) {
 }
 
 func TestHstoreArrayAssignTo(t *testing.T) {
-	var m []map[string]string
+	var hstoreSlice []map[string]string
+	var hstoreSliceDim2 [][]map[string]string
+	var hstoreSliceDim4 [][][][]map[string]string
+	var hstoreArrayDim2 [2][1]map[string]string
+	var hstoreArrayDim4 [2][1][1][3]map[string]string
 
 	simpleTests := []struct {
 		src      pgtype.HstoreArray
-		dst      *[]map[string]string
-		expected []map[string]string
+		dst      interface{}
+		expected interface{}
 	}{
 		{
 			src: pgtype.HstoreArray{
@@ -181,9 +297,127 @@ func TestHstoreArrayAssignTo(t *testing.T) {
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}},
 				Status:     pgtype.Present,
 			},
-			dst:      &m,
+			dst:      &hstoreSlice,
 			expected: []map[string]string{{"foo": "bar"}}},
-		{src: pgtype.HstoreArray{Status: pgtype.Null}, dst: &m, expected: (([]map[string]string)(nil))},
+		{
+			src: pgtype.HstoreArray{Status: pgtype.Null}, dst: &hstoreSlice, expected: (([]map[string]string)(nil)),
+		},
+		{
+			src: pgtype.HstoreArray{
+				Elements: []pgtype.Hstore{
+					{
+						Map:    map[string]pgtype.Text{"foo": {String: "bar", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"baz": {String: "quz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+				},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present,
+			},
+			dst:      &hstoreSliceDim2,
+			expected: [][]map[string]string{{{"foo": "bar"}}, {{"baz": "quz"}}},
+		},
+		{
+			src: pgtype.HstoreArray{
+				Elements: []pgtype.Hstore{
+					{
+						Map:    map[string]pgtype.Text{"foo": {String: "bar", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"baz": {String: "quz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"bar": {String: "baz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wibble": {String: "wobble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wubble": {String: "wabble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wabble": {String: "wobble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+				},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present,
+			},
+			dst: &hstoreSliceDim4,
+			expected: [][][][]map[string]string{
+				{{{{"foo": "bar"}, {"baz": "quz"}, {"bar": "baz"}}}},
+				{{{{"wibble": "wobble"}, {"wubble": "wabble"}, {"wabble": "wobble"}}}}},
+		},
+		{
+			src: pgtype.HstoreArray{
+				Elements: []pgtype.Hstore{
+					{
+						Map:    map[string]pgtype.Text{"foo": {String: "bar", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"baz": {String: "quz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+				},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present,
+			},
+			dst:      &hstoreArrayDim2,
+			expected: [2][1]map[string]string{{{"foo": "bar"}}, {{"baz": "quz"}}},
+		},
+		{
+			src: pgtype.HstoreArray{
+				Elements: []pgtype.Hstore{
+					{
+						Map:    map[string]pgtype.Text{"foo": {String: "bar", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"baz": {String: "quz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"bar": {String: "baz", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wibble": {String: "wobble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wubble": {String: "wabble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+					{
+						Map:    map[string]pgtype.Text{"wabble": {String: "wobble", Status: pgtype.Present}},
+						Status: pgtype.Present,
+					},
+				},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present,
+			},
+			dst: &hstoreArrayDim4,
+			expected: [2][1][1][3]map[string]string{
+				{{{{"foo": "bar"}, {"baz": "quz"}, {"bar": "baz"}}}},
+				{{{{"wibble": "wobble"}, {"wubble": "wabble"}, {"wabble": "wobble"}}}}},
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -192,8 +426,8 @@ func TestHstoreArrayAssignTo(t *testing.T) {
 			t.Errorf("%d: %v", i, err)
 		}
 
-		if !reflect.DeepEqual(*tt.dst, tt.expected) {
-			t.Errorf("%d: expected %v to assign %v, but result was %v", i, tt.src, tt.expected, *tt.dst)
+		if dst := reflect.ValueOf(tt.dst).Elem().Interface(); !reflect.DeepEqual(dst, tt.expected) {
+			t.Errorf("%d: expected %v to assign %v, but result was %v", i, tt.src, tt.expected, dst)
 		}
 	}
 }

--- a/inet_array.go
+++ b/inet_array.go
@@ -32,6 +32,7 @@ func (dst *InetArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []*net.IPNet:
@@ -104,6 +105,9 @@ func (dst *InetArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = InetArray{Status: Null}
@@ -209,6 +213,7 @@ func (src *InetArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]*net.IPNet:
@@ -241,6 +246,9 @@ func (src *InetArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -280,9 +288,8 @@ func (src *InetArray) assignToRecursive(value reflect.Value, index, dimension in
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/inet_array.go
+++ b/inet_array.go
@@ -5,7 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
-	"net"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,85 +31,92 @@ func (dst *InetArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = InetArray{Status: Null}
+		return nil
+	}
 
-	case []*net.IPNet:
-		if value == nil {
-			*dst = InetArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = InetArray{Status: Present}
-		} else {
-			elements := make([]Inet, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = InetArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []net.IP:
-		if value == nil {
-			*dst = InetArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = InetArray{Status: Present}
-		} else {
-			elements := make([]Inet, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = InetArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*net.IP:
-		if value == nil {
-			*dst = InetArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = InetArray{Status: Present}
-		} else {
-			elements := make([]Inet, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = InetArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Inet:
-		if value == nil {
-			*dst = InetArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = InetArray{Status: Present}
-		} else {
-			*dst = InetArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for InetArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = InetArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to InetArray", value)
+		return errors.Errorf("cannot convert %v to InetArray", src)
+	}
+
+	*dst = InetArray{
+		Elements:   make([]Inet, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Inet, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to InetArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *InetArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to InetArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in InetArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst InetArray) Get() interface{} {
@@ -126,46 +133,74 @@ func (dst InetArray) Get() interface{} {
 func (src *InetArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]*net.IPNet:
-			*v = make([]*net.IPNet, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]net.IP:
-			*v = make([]net.IP, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*net.IP:
-			*v = make([]*net.IP, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *InetArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from InetArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *InetArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/inet_array.go
+++ b/inet_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"net"
 	"reflect"
 
 	"github.com/jackc/pgio"
@@ -31,56 +32,129 @@ func (dst *InetArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = InetArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for InetArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = InetArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to InetArray", src)
-	}
-
-	*dst = InetArray{
-		Elements:   make([]Inet, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []*net.IPNet:
+		if value == nil {
+			*dst = InetArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = InetArray{Status: Present}
+		} else {
+			elements := make([]Inet, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Inet, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = InetArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []net.IP:
+		if value == nil {
+			*dst = InetArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = InetArray{Status: Present}
+		} else {
+			elements := make([]Inet, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = InetArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*net.IP:
+		if value == nil {
+			*dst = InetArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = InetArray{Status: Present}
+		} else {
+			elements := make([]Inet, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = InetArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Inet:
+		if value == nil {
+			*dst = InetArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = InetArray{Status: Present}
+		} else {
+			*dst = InetArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = InetArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for InetArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = InetArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to InetArray", src)
+		}
+
+		*dst = InetArray{
+			Elements:   make([]Inet, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Inet, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to InetArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to InetArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +169,11 @@ func (dst *InetArray) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +208,39 @@ func (dst InetArray) Get() interface{} {
 func (src *InetArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]*net.IPNet:
+				*v = make([]*net.IPNet, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]net.IP:
+				*v = make([]net.IP, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*net.IP:
+				*v = make([]*net.IP, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +279,12 @@ func (src *InetArray) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +302,14 @@ func (src *InetArray) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from InetArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from InetArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/inet_array_test.go
+++ b/inet_array_test.go
@@ -80,6 +80,74 @@ func TestInetArraySet(t *testing.T) {
 			source: (([]net.IP)(nil)),
 			result: pgtype.InetArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]net.IP{{mustParseCIDR(t, "127.0.0.1/32").IP}, {mustParseCIDR(t, "10.0.0.1/32").IP}},
+			result: pgtype.InetArray{
+				Elements: []pgtype.Inet{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/32"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]*net.IPNet{
+				{{{
+					mustParseCIDR(t, "127.0.0.1/24"),
+					mustParseCIDR(t, "10.0.0.1/24"),
+					mustParseCIDR(t, "172.16.0.1/16")}}},
+				{{{
+					mustParseCIDR(t, "192.168.0.1/16"),
+					mustParseCIDR(t, "224.0.0.1/24"),
+					mustParseCIDR(t, "169.168.0.1/16")}}}},
+			result: pgtype.InetArray{
+				Elements: []pgtype.Inet{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "172.16.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "192.168.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "224.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "169.168.0.1/16"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]net.IP{{mustParseCIDR(t, "127.0.0.1/32").IP}, {mustParseCIDR(t, "10.0.0.1/32").IP}},
+			result: pgtype.InetArray{
+				Elements: []pgtype.Inet{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/32"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]*net.IPNet{
+				{{{
+					mustParseCIDR(t, "127.0.0.1/24"),
+					mustParseCIDR(t, "10.0.0.1/24"),
+					mustParseCIDR(t, "172.16.0.1/16")}}},
+				{{{
+					mustParseCIDR(t, "192.168.0.1/16"),
+					mustParseCIDR(t, "224.0.0.1/24"),
+					mustParseCIDR(t, "169.168.0.1/16")}}}},
+			result: pgtype.InetArray{
+				Elements: []pgtype.Inet{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "172.16.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "192.168.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "224.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "169.168.0.1/16"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -98,6 +166,10 @@ func TestInetArraySet(t *testing.T) {
 func TestInetArrayAssignTo(t *testing.T) {
 	var ipnetSlice []*net.IPNet
 	var ipSlice []net.IP
+	var ipSliceDim2 [][]net.IP
+	var ipnetSliceDim4 [][][][]*net.IPNet
+	var ipArrayDim2 [2][1]net.IP
+	var ipnetArrayDim4 [2][1][1][3]*net.IPNet
 
 	simpleTests := []struct {
 		src      pgtype.InetArray
@@ -149,6 +221,78 @@ func TestInetArrayAssignTo(t *testing.T) {
 			src:      pgtype.InetArray{Status: pgtype.Null},
 			dst:      &ipSlice,
 			expected: (([]net.IP)(nil)),
+		},
+		{
+			src: pgtype.InetArray{
+				Elements: []pgtype.Inet{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/32"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &ipSliceDim2,
+			expected: [][]net.IP{{mustParseCIDR(t, "127.0.0.1/32").IP}, {mustParseCIDR(t, "10.0.0.1/32").IP}},
+		},
+		{
+			src: pgtype.InetArray{
+				Elements: []pgtype.Inet{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "172.16.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "192.168.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "224.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "169.168.0.1/16"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &ipnetSliceDim4,
+			expected: [][][][]*net.IPNet{
+				{{{
+					mustParseCIDR(t, "127.0.0.1/24"),
+					mustParseCIDR(t, "10.0.0.1/24"),
+					mustParseCIDR(t, "172.16.0.1/16")}}},
+				{{{
+					mustParseCIDR(t, "192.168.0.1/16"),
+					mustParseCIDR(t, "224.0.0.1/24"),
+					mustParseCIDR(t, "169.168.0.1/16")}}}},
+		},
+		{
+			src: pgtype.InetArray{
+				Elements: []pgtype.Inet{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/32"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &ipArrayDim2,
+			expected: [2][1]net.IP{{mustParseCIDR(t, "127.0.0.1/32").IP}, {mustParseCIDR(t, "10.0.0.1/32").IP}},
+		},
+		{
+			src: pgtype.InetArray{
+				Elements: []pgtype.Inet{
+					{IPNet: mustParseCIDR(t, "127.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "10.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "172.16.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "192.168.0.1/16"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "224.0.0.1/24"), Status: pgtype.Present},
+					{IPNet: mustParseCIDR(t, "169.168.0.1/16"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &ipnetArrayDim4,
+			expected: [2][1][1][3]*net.IPNet{
+				{{{
+					mustParseCIDR(t, "127.0.0.1/24"),
+					mustParseCIDR(t, "10.0.0.1/24"),
+					mustParseCIDR(t, "172.16.0.1/16")}}},
+				{{{
+					mustParseCIDR(t, "192.168.0.1/16"),
+					mustParseCIDR(t, "224.0.0.1/24"),
+					mustParseCIDR(t, "169.168.0.1/16")}}}},
 		},
 	}
 

--- a/int2_array.go
+++ b/int2_array.go
@@ -31,56 +31,376 @@ func (dst *Int2Array) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = Int2Array{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for Int2Array", src)
-	}
-	if elementsLength == 0 {
-		*dst = Int2Array{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to Int2Array", src)
-	}
-
-	*dst = Int2Array{
-		Elements:   make([]Int2, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []int16:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Int2, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int16:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint16:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint16:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int32:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int32:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint32:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint32:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int64:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int64:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint64:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint64:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			elements := make([]Int2, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int2Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Int2:
+		if value == nil {
+			*dst = Int2Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int2Array{Status: Present}
+		} else {
+			*dst = Int2Array{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = Int2Array{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for Int2Array", src)
+		}
+		if elementsLength == 0 {
+			*dst = Int2Array{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to Int2Array", src)
+		}
+
+		*dst = Int2Array{
+			Elements:   make([]Int2, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Int2, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to Int2Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to Int2Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +415,11 @@ func (dst *Int2Array) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +454,156 @@ func (dst Int2Array) Get() interface{} {
 func (src *Int2Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]int16:
+				*v = make([]int16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int16:
+				*v = make([]*int16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint16:
+				*v = make([]uint16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint16:
+				*v = make([]*uint16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int32:
+				*v = make([]int32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int32:
+				*v = make([]*int32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint32:
+				*v = make([]uint32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint32:
+				*v = make([]*uint32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int64:
+				*v = make([]int64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int64:
+				*v = make([]*int64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint64:
+				*v = make([]uint64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint64:
+				*v = make([]*uint64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int:
+				*v = make([]int, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int:
+				*v = make([]*int, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint:
+				*v = make([]uint, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint:
+				*v = make([]*uint, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +642,12 @@ func (src *Int2Array) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +665,14 @@ func (src *Int2Array) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from Int2Array")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Int2Array")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/int2_array.go
+++ b/int2_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,332 +31,92 @@ func (dst *Int2Array) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = Int2Array{Status: Null}
+		return nil
+	}
 
-	case []int16:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int16:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint16:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint16:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int32:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int32:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint32:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint32:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int64:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int64:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint64:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint64:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			elements := make([]Int2, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int2Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Int2:
-		if value == nil {
-			*dst = Int2Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int2Array{Status: Present}
-		} else {
-			*dst = Int2Array{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for Int2Array", src)
+	}
+	if elementsLength == 0 {
+		*dst = Int2Array{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to Int2Array", value)
+		return errors.Errorf("cannot convert %v to Int2Array", src)
+	}
+
+	*dst = Int2Array{
+		Elements:   make([]Int2, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Int2, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to Int2Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *Int2Array) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to Int2Array")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in Int2Array", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst Int2Array) Get() interface{} {
@@ -372,163 +133,74 @@ func (dst Int2Array) Get() interface{} {
 func (src *Int2Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]int16:
-			*v = make([]int16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int16:
-			*v = make([]*int16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint16:
-			*v = make([]uint16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint16:
-			*v = make([]*uint16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int32:
-			*v = make([]int32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int32:
-			*v = make([]*int32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint32:
-			*v = make([]uint32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint32:
-			*v = make([]*uint32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int64:
-			*v = make([]int64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int64:
-			*v = make([]*int64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint64:
-			*v = make([]uint64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint64:
-			*v = make([]*uint64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int:
-			*v = make([]int, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int:
-			*v = make([]*int, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint:
-			*v = make([]uint, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint:
-			*v = make([]*uint, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *Int2Array) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Int2Array")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *Int2Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/int2_array.go
+++ b/int2_array.go
@@ -31,6 +31,7 @@ func (dst *Int2Array) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []int16:
@@ -350,6 +351,9 @@ func (dst *Int2Array) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = Int2Array{Status: Null}
@@ -455,6 +459,7 @@ func (src *Int2Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]int16:
@@ -604,6 +609,9 @@ func (src *Int2Array) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -643,9 +651,8 @@ func (src *Int2Array) assignToRecursive(value reflect.Value, index, dimension in
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/int2_array_test.go
+++ b/int2_array_test.go
@@ -110,6 +110,54 @@ func TestInt2ArraySet(t *testing.T) {
 			source: (([]int16)(nil)),
 			result: pgtype.Int2Array{Status: pgtype.Null},
 		},
+		{
+			source: [][]int16{{1}, {2}},
+			result: pgtype.Int2Array{
+				Elements:   []pgtype.Int2{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]int16{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Int2Array{
+				Elements: []pgtype.Int2{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]int16{{1}, {2}},
+			result: pgtype.Int2Array{
+				Elements:   []pgtype.Int2{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]int16{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Int2Array{
+				Elements: []pgtype.Int2{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -129,6 +177,10 @@ func TestInt2ArrayAssignTo(t *testing.T) {
 	var int16Slice []int16
 	var uint16Slice []uint16
 	var namedInt16Slice _int16Slice
+	var int16SliceDim2 [][]int16
+	var int16SliceDim4 [][][][]int16
+	var int16ArrayDim2 [2][1]int16
+	var int16ArrayDim4 [2][1][1][3]int16
 
 	simpleTests := []struct {
 		src      pgtype.Int2Array
@@ -167,6 +219,58 @@ func TestInt2ArrayAssignTo(t *testing.T) {
 			dst:      &int16Slice,
 			expected: (([]int16)(nil)),
 		},
+		{
+			src: pgtype.Int2Array{
+				Elements:   []pgtype.Int2{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [][]int16{{1}, {2}},
+			dst:      &int16SliceDim2,
+		},
+		{
+			src: pgtype.Int2Array{
+				Elements: []pgtype.Int2{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [][][][]int16{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &int16SliceDim4,
+		},
+		{
+			src: pgtype.Int2Array{
+				Elements:   []pgtype.Int2{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [2][1]int16{{1}, {2}},
+			dst:      &int16ArrayDim2,
+		},
+		{
+			src: pgtype.Int2Array{
+				Elements: []pgtype.Int2{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [2][1][1][3]int16{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &int16ArrayDim4,
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -199,6 +303,27 @@ func TestInt2ArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &uint16Slice,
+		},
+		{
+			src: pgtype.Int2Array{
+				Elements:   []pgtype.Int2{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &int16ArrayDim2,
+		},
+		{
+			src: pgtype.Int2Array{
+				Elements:   []pgtype.Int2{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &int16Slice,
+		},
+		{
+			src: pgtype.Int2Array{
+				Elements:   []pgtype.Int2{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &int16ArrayDim4,
 		},
 	}
 

--- a/int4_array.go
+++ b/int4_array.go
@@ -31,6 +31,7 @@ func (dst *Int4Array) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []int16:
@@ -350,6 +351,9 @@ func (dst *Int4Array) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = Int4Array{Status: Null}
@@ -455,6 +459,7 @@ func (src *Int4Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]int16:
@@ -604,6 +609,9 @@ func (src *Int4Array) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -643,9 +651,8 @@ func (src *Int4Array) assignToRecursive(value reflect.Value, index, dimension in
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/int4_array.go
+++ b/int4_array.go
@@ -31,56 +31,376 @@ func (dst *Int4Array) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = Int4Array{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for Int4Array", src)
-	}
-	if elementsLength == 0 {
-		*dst = Int4Array{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to Int4Array", src)
-	}
-
-	*dst = Int4Array{
-		Elements:   make([]Int4, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []int16:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Int4, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int16:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint16:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint16:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int32:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int32:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint32:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint32:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int64:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int64:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint64:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint64:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Int4:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			*dst = Int4Array{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = Int4Array{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for Int4Array", src)
+		}
+		if elementsLength == 0 {
+			*dst = Int4Array{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to Int4Array", src)
+		}
+
+		*dst = Int4Array{
+			Elements:   make([]Int4, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Int4, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to Int4Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to Int4Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +415,11 @@ func (dst *Int4Array) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +454,156 @@ func (dst Int4Array) Get() interface{} {
 func (src *Int4Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]int16:
+				*v = make([]int16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int16:
+				*v = make([]*int16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint16:
+				*v = make([]uint16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint16:
+				*v = make([]*uint16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int32:
+				*v = make([]int32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int32:
+				*v = make([]*int32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint32:
+				*v = make([]uint32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint32:
+				*v = make([]*uint32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int64:
+				*v = make([]int64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int64:
+				*v = make([]*int64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint64:
+				*v = make([]uint64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint64:
+				*v = make([]*uint64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int:
+				*v = make([]int, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int:
+				*v = make([]*int, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint:
+				*v = make([]uint, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint:
+				*v = make([]*uint, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +642,12 @@ func (src *Int4Array) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +665,14 @@ func (src *Int4Array) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from Int4Array")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Int4Array")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/int4_array.go
+++ b/int4_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,332 +31,92 @@ func (dst *Int4Array) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = Int4Array{Status: Null}
+		return nil
+	}
 
-	case []int16:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int16:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint16:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint16:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int32:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int32:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint32:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint32:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int64:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int64:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint64:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint64:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			elements := make([]Int4, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int4Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Int4:
-		if value == nil {
-			*dst = Int4Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int4Array{Status: Present}
-		} else {
-			*dst = Int4Array{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for Int4Array", src)
+	}
+	if elementsLength == 0 {
+		*dst = Int4Array{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to Int4Array", value)
+		return errors.Errorf("cannot convert %v to Int4Array", src)
+	}
+
+	*dst = Int4Array{
+		Elements:   make([]Int4, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Int4, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to Int4Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *Int4Array) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to Int4Array")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in Int4Array", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst Int4Array) Get() interface{} {
@@ -372,163 +133,74 @@ func (dst Int4Array) Get() interface{} {
 func (src *Int4Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]int16:
-			*v = make([]int16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int16:
-			*v = make([]*int16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint16:
-			*v = make([]uint16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint16:
-			*v = make([]*uint16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int32:
-			*v = make([]int32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int32:
-			*v = make([]*int32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint32:
-			*v = make([]uint32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint32:
-			*v = make([]*uint32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int64:
-			*v = make([]int64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int64:
-			*v = make([]*int64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint64:
-			*v = make([]uint64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint64:
-			*v = make([]*uint64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int:
-			*v = make([]int, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int:
-			*v = make([]*int, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint:
-			*v = make([]uint, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint:
-			*v = make([]*uint, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *Int4Array) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Int4Array")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *Int4Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/int4_array_test.go
+++ b/int4_array_test.go
@@ -116,6 +116,54 @@ func TestInt4ArraySet(t *testing.T) {
 			source: (([]int32)(nil)),
 			result: pgtype.Int4Array{Status: pgtype.Null},
 		},
+		{
+			source: [][]int32{{1}, {2}},
+			result: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]int32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Int4Array{
+				Elements: []pgtype.Int4{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]int32{{1}, {2}},
+			result: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]int32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Int4Array{
+				Elements: []pgtype.Int4{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -143,6 +191,10 @@ func TestInt4ArrayAssignTo(t *testing.T) {
 	var int32Slice []int32
 	var uint32Slice []uint32
 	var namedInt32Slice _int32Slice
+	var int32SliceDim2 [][]int32
+	var int32SliceDim4 [][][][]int32
+	var int32ArrayDim2 [2][1]int32
+	var int32ArrayDim4 [2][1][1][3]int32
 
 	simpleTests := []struct {
 		src      pgtype.Int4Array
@@ -181,6 +233,58 @@ func TestInt4ArrayAssignTo(t *testing.T) {
 			dst:      &int32Slice,
 			expected: (([]int32)(nil)),
 		},
+		{
+			src: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [][]int32{{1}, {2}},
+			dst:      &int32SliceDim2,
+		},
+		{
+			src: pgtype.Int4Array{
+				Elements: []pgtype.Int4{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [][][][]int32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &int32SliceDim4,
+		},
+		{
+			src: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [2][1]int32{{1}, {2}},
+			dst:      &int32ArrayDim2,
+		},
+		{
+			src: pgtype.Int4Array{
+				Elements: []pgtype.Int4{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [2][1][1][3]int32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &int32ArrayDim4,
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -213,6 +317,27 @@ func TestInt4ArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &uint32Slice,
+		},
+		{
+			src: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &int32ArrayDim2,
+		},
+		{
+			src: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &int32Slice,
+		},
+		{
+			src: pgtype.Int4Array{
+				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &int32ArrayDim4,
 		},
 	}
 

--- a/int8_array.go
+++ b/int8_array.go
@@ -31,56 +31,376 @@ func (dst *Int8Array) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = Int8Array{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for Int8Array", src)
-	}
-	if elementsLength == 0 {
-		*dst = Int8Array{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to Int8Array", src)
-	}
-
-	*dst = Int8Array{
-		Elements:   make([]Int8, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []int16:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Int8, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int16:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint16:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint16:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int32:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int32:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint32:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint32:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int64:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int64:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint64:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint64:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			elements := make([]Int8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Int8:
+		if value == nil {
+			*dst = Int8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int8Array{Status: Present}
+		} else {
+			*dst = Int8Array{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = Int8Array{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for Int8Array", src)
+		}
+		if elementsLength == 0 {
+			*dst = Int8Array{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to Int8Array", src)
+		}
+
+		*dst = Int8Array{
+			Elements:   make([]Int8, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Int8, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to Int8Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to Int8Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +415,11 @@ func (dst *Int8Array) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +454,156 @@ func (dst Int8Array) Get() interface{} {
 func (src *Int8Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]int16:
+				*v = make([]int16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int16:
+				*v = make([]*int16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint16:
+				*v = make([]uint16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint16:
+				*v = make([]*uint16, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int32:
+				*v = make([]int32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int32:
+				*v = make([]*int32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint32:
+				*v = make([]uint32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint32:
+				*v = make([]*uint32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int64:
+				*v = make([]int64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int64:
+				*v = make([]*int64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint64:
+				*v = make([]uint64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint64:
+				*v = make([]*uint64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int:
+				*v = make([]int, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int:
+				*v = make([]*int, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint:
+				*v = make([]uint, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint:
+				*v = make([]*uint, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +642,12 @@ func (src *Int8Array) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +665,14 @@ func (src *Int8Array) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from Int8Array")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Int8Array")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/int8_array.go
+++ b/int8_array.go
@@ -31,6 +31,7 @@ func (dst *Int8Array) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []int16:
@@ -350,6 +351,9 @@ func (dst *Int8Array) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = Int8Array{Status: Null}
@@ -455,6 +459,7 @@ func (src *Int8Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]int16:
@@ -604,6 +609,9 @@ func (src *Int8Array) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -643,9 +651,8 @@ func (src *Int8Array) assignToRecursive(value reflect.Value, index, dimension in
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/int8_array.go
+++ b/int8_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,332 +31,92 @@ func (dst *Int8Array) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = Int8Array{Status: Null}
+		return nil
+	}
 
-	case []int16:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int16:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint16:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint16:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int32:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int32:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint32:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint32:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int64:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int64:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint64:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint64:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			elements := make([]Int8, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = Int8Array{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Int8:
-		if value == nil {
-			*dst = Int8Array{Status: Null}
-		} else if len(value) == 0 {
-			*dst = Int8Array{Status: Present}
-		} else {
-			*dst = Int8Array{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for Int8Array", src)
+	}
+	if elementsLength == 0 {
+		*dst = Int8Array{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to Int8Array", value)
+		return errors.Errorf("cannot convert %v to Int8Array", src)
+	}
+
+	*dst = Int8Array{
+		Elements:   make([]Int8, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Int8, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to Int8Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *Int8Array) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to Int8Array")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in Int8Array", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst Int8Array) Get() interface{} {
@@ -372,163 +133,74 @@ func (dst Int8Array) Get() interface{} {
 func (src *Int8Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]int16:
-			*v = make([]int16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int16:
-			*v = make([]*int16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint16:
-			*v = make([]uint16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint16:
-			*v = make([]*uint16, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int32:
-			*v = make([]int32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int32:
-			*v = make([]*int32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint32:
-			*v = make([]uint32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint32:
-			*v = make([]*uint32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int64:
-			*v = make([]int64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int64:
-			*v = make([]*int64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint64:
-			*v = make([]uint64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint64:
-			*v = make([]*uint64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int:
-			*v = make([]int, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int:
-			*v = make([]*int, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint:
-			*v = make([]uint, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint:
-			*v = make([]*uint, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *Int8Array) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from Int8Array")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *Int8Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/int8_array_test.go
+++ b/int8_array_test.go
@@ -117,6 +117,54 @@ func TestInt8ArraySet(t *testing.T) {
 			source: (([]int64)(nil)),
 			result: pgtype.Int8Array{Status: pgtype.Null},
 		},
+		{
+			source: [][]int64{{1}, {2}},
+			result: pgtype.Int8Array{
+				Elements:   []pgtype.Int8{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]int64{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Int8Array{
+				Elements: []pgtype.Int8{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]int64{{1}, {2}},
+			result: pgtype.Int8Array{
+				Elements:   []pgtype.Int8{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]int64{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.Int8Array{
+				Elements: []pgtype.Int8{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -136,6 +184,10 @@ func TestInt8ArrayAssignTo(t *testing.T) {
 	var int64Slice []int64
 	var uint64Slice []uint64
 	var namedInt64Slice _int64Slice
+	var int64SliceDim2 [][]int64
+	var int64SliceDim4 [][][][]int64
+	var int64ArrayDim2 [2][1]int64
+	var int64ArrayDim4 [2][1][1][3]int64
 
 	simpleTests := []struct {
 		src      pgtype.Int8Array
@@ -174,6 +226,58 @@ func TestInt8ArrayAssignTo(t *testing.T) {
 			dst:      &int64Slice,
 			expected: (([]int64)(nil)),
 		},
+		{
+			src: pgtype.Int8Array{
+				Elements:   []pgtype.Int8{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [][]int64{{1}, {2}},
+			dst:      &int64SliceDim2,
+		},
+		{
+			src: pgtype.Int8Array{
+				Elements: []pgtype.Int8{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [][][][]int64{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &int64SliceDim4,
+		},
+		{
+			src: pgtype.Int8Array{
+				Elements:   []pgtype.Int8{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			expected: [2][1]int64{{1}, {2}},
+			dst:      &int64ArrayDim2,
+		},
+		{
+			src: pgtype.Int8Array{
+				Elements: []pgtype.Int8{
+					{Int: 1, Status: pgtype.Present},
+					{Int: 2, Status: pgtype.Present},
+					{Int: 3, Status: pgtype.Present},
+					{Int: 4, Status: pgtype.Present},
+					{Int: 5, Status: pgtype.Present},
+					{Int: 6, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			expected: [2][1][1][3]int64{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			dst:      &int64ArrayDim4,
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -206,6 +310,27 @@ func TestInt8ArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &uint64Slice,
+		},
+		{
+			src: pgtype.Int8Array{
+				Elements:   []pgtype.Int8{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &int64ArrayDim2,
+		},
+		{
+			src: pgtype.Int8Array{
+				Elements:   []pgtype.Int8{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &int64Slice,
+		},
+		{
+			src: pgtype.Int8Array{
+				Elements:   []pgtype.Int8{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &int64ArrayDim4,
 		},
 	}
 

--- a/jsonb_array.go
+++ b/jsonb_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,47 +31,92 @@ func (dst *JSONBArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = JSONBArray{Status: Null}
+		return nil
+	}
 
-	case []string:
-		if value == nil {
-			*dst = JSONBArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = JSONBArray{Status: Present}
-		} else {
-			elements := make([]Text, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = JSONBArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Text:
-		if value == nil {
-			*dst = JSONBArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = JSONBArray{Status: Present}
-		} else {
-			*dst = JSONBArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for JSONBArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = JSONBArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to JSONBArray", value)
+		return errors.Errorf("cannot convert %v to JSONBArray", src)
+	}
+
+	*dst = JSONBArray{
+		Elements:   make([]Text, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Text, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to JSONBArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *JSONBArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to JSONBArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in JSONBArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst JSONBArray) Get() interface{} {
@@ -87,28 +133,74 @@ func (dst JSONBArray) Get() interface{} {
 func (src *JSONBArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]string:
-			*v = make([]string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *JSONBArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from JSONBArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *JSONBArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/jsonb_array.go
+++ b/jsonb_array.go
@@ -31,56 +31,91 @@ func (dst *JSONBArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = JSONBArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for JSONBArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = JSONBArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to JSONBArray", src)
-	}
-
-	*dst = JSONBArray{
-		Elements:   make([]Text, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []string:
+		if value == nil {
+			*dst = JSONBArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = JSONBArray{Status: Present}
+		} else {
+			elements := make([]Text, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Text, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = JSONBArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Text:
+		if value == nil {
+			*dst = JSONBArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = JSONBArray{Status: Present}
+		} else {
+			*dst = JSONBArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = JSONBArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for JSONBArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = JSONBArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to JSONBArray", src)
+		}
+
+		*dst = JSONBArray{
+			Elements:   make([]Text, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Text, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to JSONBArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to JSONBArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +130,11 @@ func (dst *JSONBArray) setRecursive(value reflect.Value, index, dimension int) (
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +169,21 @@ func (dst JSONBArray) Get() interface{} {
 func (src *JSONBArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]string:
+				*v = make([]string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +222,12 @@ func (src *JSONBArray) assignToRecursive(value reflect.Value, index, dimension i
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +245,14 @@ func (src *JSONBArray) assignToRecursive(value reflect.Value, index, dimension i
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from JSONBArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from JSONBArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/jsonb_array.go
+++ b/jsonb_array.go
@@ -31,6 +31,7 @@ func (dst *JSONBArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []string:
@@ -65,6 +66,9 @@ func (dst *JSONBArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = JSONBArray{Status: Null}
@@ -170,6 +174,7 @@ func (src *JSONBArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]string:
@@ -184,6 +189,9 @@ func (src *JSONBArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -223,9 +231,8 @@ func (src *JSONBArray) assignToRecursive(value reflect.Value, index, dimension i
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/macaddr_array.go
+++ b/macaddr_array.go
@@ -5,7 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
-	"net"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,66 +31,92 @@ func (dst *MacaddrArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = MacaddrArray{Status: Null}
+		return nil
+	}
 
-	case []net.HardwareAddr:
-		if value == nil {
-			*dst = MacaddrArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = MacaddrArray{Status: Present}
-		} else {
-			elements := make([]Macaddr, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = MacaddrArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*net.HardwareAddr:
-		if value == nil {
-			*dst = MacaddrArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = MacaddrArray{Status: Present}
-		} else {
-			elements := make([]Macaddr, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = MacaddrArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Macaddr:
-		if value == nil {
-			*dst = MacaddrArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = MacaddrArray{Status: Present}
-		} else {
-			*dst = MacaddrArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for MacaddrArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = MacaddrArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to MacaddrArray", value)
+		return errors.Errorf("cannot convert %v to MacaddrArray", src)
+	}
+
+	*dst = MacaddrArray{
+		Elements:   make([]Macaddr, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Macaddr, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to MacaddrArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *MacaddrArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to MacaddrArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in MacaddrArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst MacaddrArray) Get() interface{} {
@@ -107,37 +133,74 @@ func (dst MacaddrArray) Get() interface{} {
 func (src *MacaddrArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]net.HardwareAddr:
-			*v = make([]net.HardwareAddr, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*net.HardwareAddr:
-			*v = make([]*net.HardwareAddr, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *MacaddrArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from MacaddrArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *MacaddrArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/macaddr_array.go
+++ b/macaddr_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"net"
 	"reflect"
 
 	"github.com/jackc/pgio"
@@ -31,56 +32,110 @@ func (dst *MacaddrArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = MacaddrArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for MacaddrArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = MacaddrArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to MacaddrArray", src)
-	}
-
-	*dst = MacaddrArray{
-		Elements:   make([]Macaddr, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []net.HardwareAddr:
+		if value == nil {
+			*dst = MacaddrArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = MacaddrArray{Status: Present}
+		} else {
+			elements := make([]Macaddr, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Macaddr, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = MacaddrArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*net.HardwareAddr:
+		if value == nil {
+			*dst = MacaddrArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = MacaddrArray{Status: Present}
+		} else {
+			elements := make([]Macaddr, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = MacaddrArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Macaddr:
+		if value == nil {
+			*dst = MacaddrArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = MacaddrArray{Status: Present}
+		} else {
+			*dst = MacaddrArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = MacaddrArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for MacaddrArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = MacaddrArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to MacaddrArray", src)
+		}
+
+		*dst = MacaddrArray{
+			Elements:   make([]Macaddr, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Macaddr, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to MacaddrArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to MacaddrArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +150,11 @@ func (dst *MacaddrArray) setRecursive(value reflect.Value, index, dimension int)
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +189,30 @@ func (dst MacaddrArray) Get() interface{} {
 func (src *MacaddrArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]net.HardwareAddr:
+				*v = make([]net.HardwareAddr, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*net.HardwareAddr:
+				*v = make([]*net.HardwareAddr, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +251,12 @@ func (src *MacaddrArray) assignToRecursive(value reflect.Value, index, dimension
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +274,14 @@ func (src *MacaddrArray) assignToRecursive(value reflect.Value, index, dimension
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from MacaddrArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from MacaddrArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/macaddr_array.go
+++ b/macaddr_array.go
@@ -32,6 +32,7 @@ func (dst *MacaddrArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []net.HardwareAddr:
@@ -85,6 +86,9 @@ func (dst *MacaddrArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = MacaddrArray{Status: Null}
@@ -190,6 +194,7 @@ func (src *MacaddrArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]net.HardwareAddr:
@@ -213,6 +218,9 @@ func (src *MacaddrArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -252,9 +260,8 @@ func (src *MacaddrArray) assignToRecursive(value reflect.Value, index, dimension
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/macaddr_array_test.go
+++ b/macaddr_array_test.go
@@ -44,6 +44,78 @@ func TestMacaddrArraySet(t *testing.T) {
 			source: (([]net.HardwareAddr)(nil)),
 			result: pgtype.MacaddrArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]net.HardwareAddr{
+				{mustParseMacaddr(t, "01:23:45:67:89:ab")},
+				{mustParseMacaddr(t, "cd:ef:01:23:45:67")}},
+			result: pgtype.MacaddrArray{
+				Elements: []pgtype.Macaddr{
+					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "cd:ef:01:23:45:67"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]net.HardwareAddr{
+				{{{
+					mustParseMacaddr(t, "01:23:45:67:89:ab"),
+					mustParseMacaddr(t, "cd:ef:01:23:45:67"),
+					mustParseMacaddr(t, "89:ab:cd:ef:01:23")}}},
+				{{{
+					mustParseMacaddr(t, "45:67:89:ab:cd:ef"),
+					mustParseMacaddr(t, "fe:dc:ba:98:76:54"),
+					mustParseMacaddr(t, "32:10:fe:dc:ba:98")}}}},
+			result: pgtype.MacaddrArray{
+				Elements: []pgtype.Macaddr{
+					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "cd:ef:01:23:45:67"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "89:ab:cd:ef:01:23"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "45:67:89:ab:cd:ef"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "fe:dc:ba:98:76:54"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "32:10:fe:dc:ba:98"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]net.HardwareAddr{
+				{mustParseMacaddr(t, "01:23:45:67:89:ab")},
+				{mustParseMacaddr(t, "cd:ef:01:23:45:67")}},
+			result: pgtype.MacaddrArray{
+				Elements: []pgtype.Macaddr{
+					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "cd:ef:01:23:45:67"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]net.HardwareAddr{
+				{{{
+					mustParseMacaddr(t, "01:23:45:67:89:ab"),
+					mustParseMacaddr(t, "cd:ef:01:23:45:67"),
+					mustParseMacaddr(t, "89:ab:cd:ef:01:23")}}},
+				{{{
+					mustParseMacaddr(t, "45:67:89:ab:cd:ef"),
+					mustParseMacaddr(t, "fe:dc:ba:98:76:54"),
+					mustParseMacaddr(t, "32:10:fe:dc:ba:98")}}}},
+			result: pgtype.MacaddrArray{
+				Elements: []pgtype.Macaddr{
+					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "cd:ef:01:23:45:67"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "89:ab:cd:ef:01:23"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "45:67:89:ab:cd:ef"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "fe:dc:ba:98:76:54"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "32:10:fe:dc:ba:98"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -61,6 +133,10 @@ func TestMacaddrArraySet(t *testing.T) {
 
 func TestMacaddrArrayAssignTo(t *testing.T) {
 	var macaddrSlice []net.HardwareAddr
+	var macaddrSliceDim2 [][]net.HardwareAddr
+	var macaddrSliceDim4 [][][][]net.HardwareAddr
+	var macaddrArrayDim2 [2][1]net.HardwareAddr
+	var macaddrArrayDim4 [2][1][1][3]net.HardwareAddr
 
 	simpleTests := []struct {
 		src      pgtype.MacaddrArray
@@ -89,6 +165,82 @@ func TestMacaddrArrayAssignTo(t *testing.T) {
 			src:      pgtype.MacaddrArray{Status: pgtype.Null},
 			dst:      &macaddrSlice,
 			expected: (([]net.HardwareAddr)(nil)),
+		},
+		{
+			src: pgtype.MacaddrArray{
+				Elements: []pgtype.Macaddr{
+					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "cd:ef:01:23:45:67"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &macaddrSliceDim2,
+			expected: [][]net.HardwareAddr{
+				{mustParseMacaddr(t, "01:23:45:67:89:ab")},
+				{mustParseMacaddr(t, "cd:ef:01:23:45:67")}},
+		},
+		{
+			src: pgtype.MacaddrArray{
+				Elements: []pgtype.Macaddr{
+					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "cd:ef:01:23:45:67"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "89:ab:cd:ef:01:23"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "45:67:89:ab:cd:ef"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "fe:dc:ba:98:76:54"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "32:10:fe:dc:ba:98"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &macaddrSliceDim4,
+			expected: [][][][]net.HardwareAddr{
+				{{{
+					mustParseMacaddr(t, "01:23:45:67:89:ab"),
+					mustParseMacaddr(t, "cd:ef:01:23:45:67"),
+					mustParseMacaddr(t, "89:ab:cd:ef:01:23")}}},
+				{{{
+					mustParseMacaddr(t, "45:67:89:ab:cd:ef"),
+					mustParseMacaddr(t, "fe:dc:ba:98:76:54"),
+					mustParseMacaddr(t, "32:10:fe:dc:ba:98")}}}},
+		},
+		{
+			src: pgtype.MacaddrArray{
+				Elements: []pgtype.Macaddr{
+					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "cd:ef:01:23:45:67"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &macaddrArrayDim2,
+			expected: [2][1]net.HardwareAddr{
+				{mustParseMacaddr(t, "01:23:45:67:89:ab")},
+				{mustParseMacaddr(t, "cd:ef:01:23:45:67")}},
+		},
+		{
+			src: pgtype.MacaddrArray{
+				Elements: []pgtype.Macaddr{
+					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "cd:ef:01:23:45:67"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "89:ab:cd:ef:01:23"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "45:67:89:ab:cd:ef"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "fe:dc:ba:98:76:54"), Status: pgtype.Present},
+					{Addr: mustParseMacaddr(t, "32:10:fe:dc:ba:98"), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &macaddrArrayDim4,
+			expected: [2][1][1][3]net.HardwareAddr{
+				{{{
+					mustParseMacaddr(t, "01:23:45:67:89:ab"),
+					mustParseMacaddr(t, "cd:ef:01:23:45:67"),
+					mustParseMacaddr(t, "89:ab:cd:ef:01:23")}}},
+				{{{
+					mustParseMacaddr(t, "45:67:89:ab:cd:ef"),
+					mustParseMacaddr(t, "fe:dc:ba:98:76:54"),
+					mustParseMacaddr(t, "32:10:fe:dc:ba:98")}}}},
 		},
 	}
 

--- a/numeric_array.go
+++ b/numeric_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,180 +31,92 @@ func (dst *NumericArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = NumericArray{Status: Null}
+		return nil
+	}
 
-	case []float32:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			elements := make([]Numeric, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = NumericArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*float32:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			elements := make([]Numeric, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = NumericArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []float64:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			elements := make([]Numeric, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = NumericArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*float64:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			elements := make([]Numeric, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = NumericArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []int64:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			elements := make([]Numeric, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = NumericArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*int64:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			elements := make([]Numeric, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = NumericArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []uint64:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			elements := make([]Numeric, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = NumericArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*uint64:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			elements := make([]Numeric, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = NumericArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Numeric:
-		if value == nil {
-			*dst = NumericArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = NumericArray{Status: Present}
-		} else {
-			*dst = NumericArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for NumericArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = NumericArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to NumericArray", value)
+		return errors.Errorf("cannot convert %v to NumericArray", src)
+	}
+
+	*dst = NumericArray{
+		Elements:   make([]Numeric, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Numeric, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to NumericArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *NumericArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to NumericArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in NumericArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst NumericArray) Get() interface{} {
@@ -220,91 +133,74 @@ func (dst NumericArray) Get() interface{} {
 func (src *NumericArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]float32:
-			*v = make([]float32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*float32:
-			*v = make([]*float32, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]float64:
-			*v = make([]float64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*float64:
-			*v = make([]*float64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]int64:
-			*v = make([]int64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*int64:
-			*v = make([]*int64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]uint64:
-			*v = make([]uint64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*uint64:
-			*v = make([]*uint64, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *NumericArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from NumericArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *NumericArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/numeric_array.go
+++ b/numeric_array.go
@@ -31,56 +31,224 @@ func (dst *NumericArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = NumericArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for NumericArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = NumericArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to NumericArray", src)
-	}
-
-	*dst = NumericArray{
-		Elements:   make([]Numeric, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []float32:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			elements := make([]Numeric, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Numeric, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = NumericArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*float32:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			elements := make([]Numeric, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = NumericArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []float64:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			elements := make([]Numeric, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = NumericArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*float64:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			elements := make([]Numeric, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = NumericArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []int64:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			elements := make([]Numeric, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = NumericArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*int64:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			elements := make([]Numeric, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = NumericArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint64:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			elements := make([]Numeric, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = NumericArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*uint64:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			elements := make([]Numeric, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = NumericArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Numeric:
+		if value == nil {
+			*dst = NumericArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = NumericArray{Status: Present}
+		} else {
+			*dst = NumericArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = NumericArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for NumericArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = NumericArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to NumericArray", src)
+		}
+
+		*dst = NumericArray{
+			Elements:   make([]Numeric, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Numeric, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to NumericArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to NumericArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +263,11 @@ func (dst *NumericArray) setRecursive(value reflect.Value, index, dimension int)
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +302,84 @@ func (dst NumericArray) Get() interface{} {
 func (src *NumericArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]float32:
+				*v = make([]float32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*float32:
+				*v = make([]*float32, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]float64:
+				*v = make([]float64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*float64:
+				*v = make([]*float64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]int64:
+				*v = make([]int64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*int64:
+				*v = make([]*int64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]uint64:
+				*v = make([]uint64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*uint64:
+				*v = make([]*uint64, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +418,12 @@ func (src *NumericArray) assignToRecursive(value reflect.Value, index, dimension
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +441,14 @@ func (src *NumericArray) assignToRecursive(value reflect.Value, index, dimension
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from NumericArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from NumericArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/numeric_array.go
+++ b/numeric_array.go
@@ -31,6 +31,7 @@ func (dst *NumericArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []float32:
@@ -198,6 +199,9 @@ func (dst *NumericArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = NumericArray{Status: Null}
@@ -303,6 +307,7 @@ func (src *NumericArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]float32:
@@ -380,6 +385,9 @@ func (src *NumericArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -419,9 +427,8 @@ func (src *NumericArray) assignToRecursive(value reflect.Value, index, dimension
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/numeric_array_test.go
+++ b/numeric_array_test.go
@@ -91,6 +91,54 @@ func TestNumericArraySet(t *testing.T) {
 			source: (([]float32)(nil)),
 			result: pgtype.NumericArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]float32{{1}, {2}},
+			result: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}, {Int: big.NewInt(2), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]float32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.NumericArray{
+				Elements: []pgtype.Numeric{
+					{Int: big.NewInt(1), Status: pgtype.Present},
+					{Int: big.NewInt(2), Status: pgtype.Present},
+					{Int: big.NewInt(3), Status: pgtype.Present},
+					{Int: big.NewInt(4), Status: pgtype.Present},
+					{Int: big.NewInt(5), Status: pgtype.Present},
+					{Int: big.NewInt(6), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]float32{{1}, {2}},
+			result: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}, {Int: big.NewInt(2), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]float32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+			result: pgtype.NumericArray{
+				Elements: []pgtype.Numeric{
+					{Int: big.NewInt(1), Status: pgtype.Present},
+					{Int: big.NewInt(2), Status: pgtype.Present},
+					{Int: big.NewInt(3), Status: pgtype.Present},
+					{Int: big.NewInt(4), Status: pgtype.Present},
+					{Int: big.NewInt(5), Status: pgtype.Present},
+					{Int: big.NewInt(6), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -109,6 +157,10 @@ func TestNumericArraySet(t *testing.T) {
 func TestNumericArrayAssignTo(t *testing.T) {
 	var float32Slice []float32
 	var float64Slice []float64
+	var float32SliceDim2 [][]float32
+	var float32SliceDim4 [][][][]float32
+	var float32ArrayDim2 [2][1]float32
+	var float32ArrayDim4 [2][1][1][3]float32
 
 	simpleTests := []struct {
 		src      pgtype.NumericArray
@@ -138,6 +190,58 @@ func TestNumericArrayAssignTo(t *testing.T) {
 			dst:      &float32Slice,
 			expected: (([]float32)(nil)),
 		},
+		{
+			src: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}, {Int: big.NewInt(2), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &float32SliceDim2,
+			expected: [][]float32{{1}, {2}},
+		},
+		{
+			src: pgtype.NumericArray{
+				Elements: []pgtype.Numeric{
+					{Int: big.NewInt(1), Status: pgtype.Present},
+					{Int: big.NewInt(2), Status: pgtype.Present},
+					{Int: big.NewInt(3), Status: pgtype.Present},
+					{Int: big.NewInt(4), Status: pgtype.Present},
+					{Int: big.NewInt(5), Status: pgtype.Present},
+					{Int: big.NewInt(6), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &float32SliceDim4,
+			expected: [][][][]float32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+		},
+		{
+			src: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}, {Int: big.NewInt(2), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &float32ArrayDim2,
+			expected: [2][1]float32{{1}, {2}},
+		},
+		{
+			src: pgtype.NumericArray{
+				Elements: []pgtype.Numeric{
+					{Int: big.NewInt(1), Status: pgtype.Present},
+					{Int: big.NewInt(2), Status: pgtype.Present},
+					{Int: big.NewInt(3), Status: pgtype.Present},
+					{Int: big.NewInt(4), Status: pgtype.Present},
+					{Int: big.NewInt(5), Status: pgtype.Present},
+					{Int: big.NewInt(6), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &float32ArrayDim4,
+			expected: [2][1][1][3]float32{{{{1, 2, 3}}}, {{{4, 5, 6}}}},
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -162,6 +266,27 @@ func TestNumericArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &float32Slice,
+		},
+		{
+			src: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}, {Int: big.NewInt(2), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &float32ArrayDim2,
+		},
+		{
+			src: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}, {Int: big.NewInt(2), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &float32Slice,
+		},
+		{
+			src: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}, {Int: big.NewInt(2), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &float32ArrayDim4,
 		},
 	}
 

--- a/text_array.go
+++ b/text_array.go
@@ -31,6 +31,7 @@ func (dst *TextArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []string:
@@ -84,6 +85,9 @@ func (dst *TextArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = TextArray{Status: Null}
@@ -189,6 +193,7 @@ func (src *TextArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]string:
@@ -212,6 +217,9 @@ func (src *TextArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -251,9 +259,8 @@ func (src *TextArray) assignToRecursive(value reflect.Value, index, dimension in
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/text_array.go
+++ b/text_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,66 +31,92 @@ func (dst *TextArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = TextArray{Status: Null}
+		return nil
+	}
 
-	case []string:
-		if value == nil {
-			*dst = TextArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TextArray{Status: Present}
-		} else {
-			elements := make([]Text, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = TextArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*string:
-		if value == nil {
-			*dst = TextArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TextArray{Status: Present}
-		} else {
-			elements := make([]Text, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = TextArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Text:
-		if value == nil {
-			*dst = TextArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TextArray{Status: Present}
-		} else {
-			*dst = TextArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for TextArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = TextArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to TextArray", value)
+		return errors.Errorf("cannot convert %v to TextArray", src)
+	}
+
+	*dst = TextArray{
+		Elements:   make([]Text, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Text, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to TextArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *TextArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to TextArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in TextArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst TextArray) Get() interface{} {
@@ -106,37 +133,74 @@ func (dst TextArray) Get() interface{} {
 func (src *TextArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]string:
-			*v = make([]string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*string:
-			*v = make([]*string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *TextArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from TextArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *TextArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/text_array.go
+++ b/text_array.go
@@ -31,56 +31,110 @@ func (dst *TextArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = TextArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for TextArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = TextArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to TextArray", src)
-	}
-
-	*dst = TextArray{
-		Elements:   make([]Text, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []string:
+		if value == nil {
+			*dst = TextArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TextArray{Status: Present}
+		} else {
+			elements := make([]Text, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Text, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = TextArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*string:
+		if value == nil {
+			*dst = TextArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TextArray{Status: Present}
+		} else {
+			elements := make([]Text, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = TextArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Text:
+		if value == nil {
+			*dst = TextArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TextArray{Status: Present}
+		} else {
+			*dst = TextArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = TextArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for TextArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = TextArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to TextArray", src)
+		}
+
+		*dst = TextArray{
+			Elements:   make([]Text, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Text, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to TextArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to TextArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +149,11 @@ func (dst *TextArray) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +188,30 @@ func (dst TextArray) Get() interface{} {
 func (src *TextArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]string:
+				*v = make([]string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*string:
+				*v = make([]*string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +250,12 @@ func (src *TextArray) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +273,14 @@ func (src *TextArray) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from TextArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from TextArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/text_array_test.go
+++ b/text_array_test.go
@@ -68,6 +68,54 @@ func TestTextArraySet(t *testing.T) {
 			source: (([]string)(nil)),
 			result: pgtype.TextArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]string{{"foo"}, {"bar"}},
+			result: pgtype.TextArray{
+				Elements:   []pgtype.Text{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+			result: pgtype.TextArray{
+				Elements: []pgtype.Text{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]string{{"foo"}, {"bar"}},
+			result: pgtype.TextArray{
+				Elements:   []pgtype.Text{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+			result: pgtype.TextArray{
+				Elements: []pgtype.Text{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -87,6 +135,10 @@ func TestTextArrayAssignTo(t *testing.T) {
 	var stringSlice []string
 	type _stringSlice []string
 	var namedStringSlice _stringSlice
+	var stringSliceDim2 [][]string
+	var stringSliceDim4 [][][][]string
+	var stringArrayDim2 [2][1]string
+	var stringArrayDim4 [2][1][1][3]string
 
 	simpleTests := []struct {
 		src      pgtype.TextArray
@@ -116,6 +168,58 @@ func TestTextArrayAssignTo(t *testing.T) {
 			dst:      &stringSlice,
 			expected: (([]string)(nil)),
 		},
+		{
+			src: pgtype.TextArray{
+				Elements:   []pgtype.Text{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &stringSliceDim2,
+			expected: [][]string{{"foo"}, {"bar"}},
+		},
+		{
+			src: pgtype.TextArray{
+				Elements: []pgtype.Text{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &stringSliceDim4,
+			expected: [][][][]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+		},
+		{
+			src: pgtype.TextArray{
+				Elements:   []pgtype.Text{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &stringArrayDim2,
+			expected: [2][1]string{{"foo"}, {"bar"}},
+		},
+		{
+			src: pgtype.TextArray{
+				Elements: []pgtype.Text{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &stringArrayDim4,
+			expected: [2][1][1][3]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -140,6 +244,27 @@ func TestTextArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &stringSlice,
+		},
+		{
+			src: pgtype.TextArray{
+				Elements:   []pgtype.Text{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &stringArrayDim2,
+		},
+		{
+			src: pgtype.TextArray{
+				Elements:   []pgtype.Text{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &stringSlice,
+		},
+		{
+			src: pgtype.TextArray{
+				Elements:   []pgtype.Text{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &stringArrayDim4,
 		},
 	}
 

--- a/timestamp_array.go
+++ b/timestamp_array.go
@@ -5,7 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
-	"time"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,66 +31,92 @@ func (dst *TimestampArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = TimestampArray{Status: Null}
+		return nil
+	}
 
-	case []time.Time:
-		if value == nil {
-			*dst = TimestampArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TimestampArray{Status: Present}
-		} else {
-			elements := make([]Timestamp, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = TimestampArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*time.Time:
-		if value == nil {
-			*dst = TimestampArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TimestampArray{Status: Present}
-		} else {
-			elements := make([]Timestamp, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = TimestampArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Timestamp:
-		if value == nil {
-			*dst = TimestampArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TimestampArray{Status: Present}
-		} else {
-			*dst = TimestampArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for TimestampArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = TimestampArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to TimestampArray", value)
+		return errors.Errorf("cannot convert %v to TimestampArray", src)
+	}
+
+	*dst = TimestampArray{
+		Elements:   make([]Timestamp, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Timestamp, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to TimestampArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *TimestampArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to TimestampArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in TimestampArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst TimestampArray) Get() interface{} {
@@ -107,37 +133,74 @@ func (dst TimestampArray) Get() interface{} {
 func (src *TimestampArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]time.Time:
-			*v = make([]time.Time, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*time.Time:
-			*v = make([]*time.Time, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *TimestampArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from TimestampArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *TimestampArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/timestamp_array.go
+++ b/timestamp_array.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"reflect"
+	"time"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,56 +32,110 @@ func (dst *TimestampArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = TimestampArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for TimestampArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = TimestampArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to TimestampArray", src)
-	}
-
-	*dst = TimestampArray{
-		Elements:   make([]Timestamp, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []time.Time:
+		if value == nil {
+			*dst = TimestampArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TimestampArray{Status: Present}
+		} else {
+			elements := make([]Timestamp, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Timestamp, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = TimestampArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*time.Time:
+		if value == nil {
+			*dst = TimestampArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TimestampArray{Status: Present}
+		} else {
+			elements := make([]Timestamp, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = TimestampArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Timestamp:
+		if value == nil {
+			*dst = TimestampArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TimestampArray{Status: Present}
+		} else {
+			*dst = TimestampArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = TimestampArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for TimestampArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = TimestampArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to TimestampArray", src)
+		}
+
+		*dst = TimestampArray{
+			Elements:   make([]Timestamp, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Timestamp, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to TimestampArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to TimestampArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +150,11 @@ func (dst *TimestampArray) setRecursive(value reflect.Value, index, dimension in
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +189,30 @@ func (dst TimestampArray) Get() interface{} {
 func (src *TimestampArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]time.Time:
+				*v = make([]time.Time, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*time.Time:
+				*v = make([]*time.Time, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +251,12 @@ func (src *TimestampArray) assignToRecursive(value reflect.Value, index, dimensi
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +274,14 @@ func (src *TimestampArray) assignToRecursive(value reflect.Value, index, dimensi
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from TimestampArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from TimestampArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/timestamp_array.go
+++ b/timestamp_array.go
@@ -32,6 +32,7 @@ func (dst *TimestampArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []time.Time:
@@ -85,6 +86,9 @@ func (dst *TimestampArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = TimestampArray{Status: Null}
@@ -190,6 +194,7 @@ func (src *TimestampArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]time.Time:
@@ -213,6 +218,9 @@ func (src *TimestampArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -252,9 +260,8 @@ func (src *TimestampArray) assignToRecursive(value reflect.Value, index, dimensi
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/timestamp_array_test.go
+++ b/timestamp_array_test.go
@@ -85,6 +85,42 @@ func TestTimestampArraySet(t *testing.T) {
 			source: (([]time.Time)(nil)),
 			result: pgtype.TimestampArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+			result: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
+			result: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -102,6 +138,10 @@ func TestTimestampArraySet(t *testing.T) {
 
 func TestTimestampArrayAssignTo(t *testing.T) {
 	var timeSlice []time.Time
+	var timeSliceDim2 [][]time.Time
+	var timeSliceDim4 [][][][]time.Time
+	var timeArrayDim2 [2][1]time.Time
+	var timeArrayDim4 [2][1][1][3]time.Time
 
 	simpleTests := []struct {
 		src      pgtype.TimestampArray
@@ -121,6 +161,82 @@ func TestTimestampArrayAssignTo(t *testing.T) {
 			src:      pgtype.TimestampArray{Status: pgtype.Null},
 			dst:      &timeSlice,
 			expected: (([]time.Time)(nil)),
+		},
+		{
+			src: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeSliceDim2,
+			expected: [][]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+		},
+		{
+			src: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &timeSliceDim4,
+			expected: [][][][]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
+		},
+		{
+			src: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim2,
+			expected: [2][1]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+		},
+		{
+			src: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &timeArrayDim4,
+			expected: [2][1][1][3]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
 		},
 	}
 
@@ -146,6 +262,33 @@ func TestTimestampArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &timeSlice,
+		},
+		{
+			src: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim2,
+		},
+		{
+			src: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &timeSlice,
+		},
+		{
+			src: pgtype.TimestampArray{
+				Elements: []pgtype.Timestamp{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim4,
 		},
 	}
 

--- a/timestamptz_array.go
+++ b/timestamptz_array.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"reflect"
+	"time"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,56 +32,110 @@ func (dst *TimestamptzArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = TimestamptzArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for TimestamptzArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = TimestamptzArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to TimestamptzArray", src)
-	}
-
-	*dst = TimestamptzArray{
-		Elements:   make([]Timestamptz, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []time.Time:
+		if value == nil {
+			*dst = TimestamptzArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TimestamptzArray{Status: Present}
+		} else {
+			elements := make([]Timestamptz, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Timestamptz, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = TimestamptzArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*time.Time:
+		if value == nil {
+			*dst = TimestamptzArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TimestamptzArray{Status: Present}
+		} else {
+			elements := make([]Timestamptz, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = TimestamptzArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Timestamptz:
+		if value == nil {
+			*dst = TimestamptzArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TimestamptzArray{Status: Present}
+		} else {
+			*dst = TimestamptzArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = TimestamptzArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for TimestamptzArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = TimestamptzArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to TimestamptzArray", src)
+		}
+
+		*dst = TimestamptzArray{
+			Elements:   make([]Timestamptz, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Timestamptz, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to TimestamptzArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to TimestamptzArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +150,11 @@ func (dst *TimestamptzArray) setRecursive(value reflect.Value, index, dimension 
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +189,30 @@ func (dst TimestamptzArray) Get() interface{} {
 func (src *TimestamptzArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]time.Time:
+				*v = make([]time.Time, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*time.Time:
+				*v = make([]*time.Time, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +251,12 @@ func (src *TimestamptzArray) assignToRecursive(value reflect.Value, index, dimen
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +274,14 @@ func (src *TimestamptzArray) assignToRecursive(value reflect.Value, index, dimen
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from TimestamptzArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from TimestamptzArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/timestamptz_array.go
+++ b/timestamptz_array.go
@@ -5,7 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
-	"time"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -31,66 +31,92 @@ func (dst *TimestamptzArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = TimestamptzArray{Status: Null}
+		return nil
+	}
 
-	case []time.Time:
-		if value == nil {
-			*dst = TimestamptzArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TimestamptzArray{Status: Present}
-		} else {
-			elements := make([]Timestamptz, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = TimestamptzArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*time.Time:
-		if value == nil {
-			*dst = TimestamptzArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TimestamptzArray{Status: Present}
-		} else {
-			elements := make([]Timestamptz, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = TimestamptzArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Timestamptz:
-		if value == nil {
-			*dst = TimestamptzArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TimestamptzArray{Status: Present}
-		} else {
-			*dst = TimestamptzArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for TimestamptzArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = TimestamptzArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to TimestamptzArray", value)
+		return errors.Errorf("cannot convert %v to TimestamptzArray", src)
+	}
+
+	*dst = TimestamptzArray{
+		Elements:   make([]Timestamptz, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Timestamptz, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to TimestamptzArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *TimestamptzArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to TimestamptzArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in TimestamptzArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst TimestamptzArray) Get() interface{} {
@@ -107,37 +133,74 @@ func (dst TimestamptzArray) Get() interface{} {
 func (src *TimestamptzArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]time.Time:
-			*v = make([]time.Time, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*time.Time:
-			*v = make([]*time.Time, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *TimestamptzArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from TimestamptzArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *TimestamptzArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/timestamptz_array.go
+++ b/timestamptz_array.go
@@ -32,6 +32,7 @@ func (dst *TimestamptzArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []time.Time:
@@ -85,6 +86,9 @@ func (dst *TimestamptzArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = TimestamptzArray{Status: Null}
@@ -190,6 +194,7 @@ func (src *TimestamptzArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]time.Time:
@@ -213,6 +218,9 @@ func (src *TimestamptzArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -252,9 +260,8 @@ func (src *TimestamptzArray) assignToRecursive(value reflect.Value, index, dimen
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/timestamptz_array_test.go
+++ b/timestamptz_array_test.go
@@ -85,6 +85,78 @@ func TestTimestamptzArraySet(t *testing.T) {
 			source: (([]time.Time)(nil)),
 			result: pgtype.TimestamptzArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+			result: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
+			result: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+			result: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
+			result: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -102,6 +174,10 @@ func TestTimestamptzArraySet(t *testing.T) {
 
 func TestTimestamptzArrayAssignTo(t *testing.T) {
 	var timeSlice []time.Time
+	var timeSliceDim2 [][]time.Time
+	var timeSliceDim4 [][][][]time.Time
+	var timeArrayDim2 [2][1]time.Time
+	var timeArrayDim4 [2][1][1][3]time.Time
 
 	simpleTests := []struct {
 		src      pgtype.TimestamptzArray
@@ -121,6 +197,82 @@ func TestTimestamptzArrayAssignTo(t *testing.T) {
 			src:      pgtype.TimestamptzArray{Status: pgtype.Null},
 			dst:      &timeSlice,
 			expected: (([]time.Time)(nil)),
+		},
+		{
+			src: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeSliceDim2,
+			expected: [][]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+		},
+		{
+			src: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &timeSliceDim4,
+			expected: [][][][]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
+		},
+		{
+			src: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim2,
+			expected: [2][1]time.Time{
+				{time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC)},
+				{time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC)}},
+		},
+		{
+			src: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &timeArrayDim4,
+			expected: [2][1][1][3]time.Time{
+				{{{
+					time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC),
+					time.Date(2017, 5, 6, 0, 0, 0, 0, time.UTC)}}},
+				{{{
+					time.Date(2018, 7, 8, 0, 0, 0, 0, time.UTC),
+					time.Date(2019, 9, 10, 0, 0, 0, 0, time.UTC),
+					time.Date(2020, 11, 12, 0, 0, 0, 0, time.UTC)}}}},
 		},
 	}
 
@@ -146,6 +298,33 @@ func TestTimestamptzArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &timeSlice,
+		},
+		{
+			src: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim2,
+		},
+		{
+			src: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &timeSlice,
+		},
+		{
+			src: pgtype.TimestamptzArray{
+				Elements: []pgtype.Timestamptz{
+					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},
+					{Time: time.Date(2016, 3, 4, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &timeArrayDim4,
 		},
 	}
 

--- a/tstzrange_array.go
+++ b/tstzrange_array.go
@@ -31,56 +31,72 @@ func (dst *TstzrangeArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = TstzrangeArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for TstzrangeArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = TstzrangeArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to TstzrangeArray", src)
-	}
-
-	*dst = TstzrangeArray{
-		Elements:   make([]Tstzrange, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
-				}
+	case []Tstzrange:
+		if value == nil {
+			*dst = TstzrangeArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = TstzrangeArray{Status: Present}
+		} else {
+			*dst = TstzrangeArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
 			}
-			dst.Elements = make([]Tstzrange, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = TstzrangeArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for TstzrangeArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = TstzrangeArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to TstzrangeArray", src)
+		}
+
+		*dst = TstzrangeArray{
+			Elements:   make([]Tstzrange, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Tstzrange, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to TstzrangeArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to TstzrangeArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +111,11 @@ func (dst *TstzrangeArray) setRecursive(value reflect.Value, index, dimension in
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +150,21 @@ func (dst TstzrangeArray) Get() interface{} {
 func (src *TstzrangeArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]Tstzrange:
+				*v = make([]Tstzrange, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +203,12 @@ func (src *TstzrangeArray) assignToRecursive(value reflect.Value, index, dimensi
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +226,14 @@ func (src *TstzrangeArray) assignToRecursive(value reflect.Value, index, dimensi
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from TstzrangeArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from TstzrangeArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/tstzrange_array.go
+++ b/tstzrange_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,28 +31,92 @@ func (dst *TstzrangeArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = TstzrangeArray{Status: Null}
+		return nil
+	}
 
-	case []Tstzrange:
-		if value == nil {
-			*dst = TstzrangeArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = TstzrangeArray{Status: Present}
-		} else {
-			*dst = TstzrangeArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for TstzrangeArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = TstzrangeArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to TstzrangeArray", value)
+		return errors.Errorf("cannot convert %v to TstzrangeArray", src)
+	}
+
+	*dst = TstzrangeArray{
+		Elements:   make([]Tstzrange, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Tstzrange, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to TstzrangeArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *TstzrangeArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to TstzrangeArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in TstzrangeArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst TstzrangeArray) Get() interface{} {
@@ -68,28 +133,74 @@ func (dst TstzrangeArray) Get() interface{} {
 func (src *TstzrangeArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]Tstzrange:
-			*v = make([]Tstzrange, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *TstzrangeArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from TstzrangeArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *TstzrangeArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/typed_array.go.erb
+++ b/typed_array.go.erb
@@ -30,6 +30,7 @@ func (dst *<%= pgtype_array_type %>) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 	<% go_array_types.split(",").each do |t| %>
 	<% if t != "[]#{pgtype_element_type}" %>
@@ -66,6 +67,9 @@ func (dst *<%= pgtype_array_type %>) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = <%= pgtype_array_type %>{Status: Null}
@@ -171,6 +175,7 @@ func (src *<%= pgtype_array_type %>) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1{
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 			<% go_array_types.split(",").each do |t| %>
 			case *<%= t %>:
@@ -185,6 +190,9 @@ func (src *<%= pgtype_array_type %>) AssignTo(dst interface{}) error {
 			}
 		}
 		
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -224,9 +232,8 @@ func (src *<%= pgtype_array_type %>) assignToRecursive(value reflect.Value, inde
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/typed_array.go.erb
+++ b/typed_array.go.erb
@@ -30,49 +30,92 @@ func (dst *<%= pgtype_array_type %>) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
-	<% go_array_types.split(",").each do |t| %>
-	<% if t != "[]#{pgtype_element_type}" %>
-	case <%= t %>:
-		if value == nil {
-			*dst = <%= pgtype_array_type %>{Status: Null}
-		} else if len(value) == 0 {
-			*dst = <%= pgtype_array_type %>{Status: Present}
-		} else {
-			elements := make([]<%= pgtype_element_type %>, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = <%= pgtype_array_type %>{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	<% end %>
-	<% end %>
-	case []<%= pgtype_element_type %>:
-		if value == nil {
-			*dst = <%= pgtype_array_type %>{Status: Null}
-		} else if len(value) == 0 {
-			*dst = <%= pgtype_array_type %>{Status: Present}
-		} else {
-			*dst = <%= pgtype_array_type %>{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status    : Present,
-			}
-		}
-	default:
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = <%= pgtype_array_type %>{Status: Null}
+		return nil
+	}
+
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for <%= pgtype_array_type %>", src)
+	}
+	if elementsLength == 0 {
+		*dst = <%= pgtype_array_type %>{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to <%= pgtype_array_type %>", value)
+		return errors.Errorf("cannot convert %v to <%= pgtype_array_type %>", src)
+	}
+
+	*dst = <%= pgtype_array_type %> {
+		Elements:   make([]<%= pgtype_element_type %>, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]<%= pgtype_element_type %>, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil  {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to <%= pgtype_array_type %>, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *<%= pgtype_array_type %>) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+		
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to <%= pgtype_array_type %>")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in <%= pgtype_array_type %>", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst <%= pgtype_array_type %>) Get() interface{} {
@@ -89,28 +132,74 @@ func (dst <%= pgtype_array_type %>) Get() interface{} {
 func (src *<%= pgtype_array_type %>) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-		<% go_array_types.split(",").each do |t| %>
-		case *<%= t %>:
-			*v = make(<%= t %>, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-		<% end %>
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+		
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *<%= pgtype_array_type %>) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from <%= pgtype_array_type %>")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *<%= pgtype_array_type %>) DecodeText(ci *ConnInfo, src []byte) error {

--- a/typed_array.go.erb
+++ b/typed_array.go.erb
@@ -30,56 +30,93 @@ func (dst *<%= pgtype_array_type %>) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = <%= pgtype_array_type %>{Status: Null}
-		return nil
-	}
-
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for <%= pgtype_array_type %>", src)
-	}
-	if elementsLength == 0 {
-		*dst = <%= pgtype_array_type %>{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to <%= pgtype_array_type %>", src)
-	}
-
-	*dst = <%= pgtype_array_type %> {
-		Elements:   make([]<%= pgtype_element_type %>, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	switch value := src.(type) {
+	<% go_array_types.split(",").each do |t| %>
+	<% if t != "[]#{pgtype_element_type}" %>
+	case <%= t %>:
+		if value == nil {
+			*dst = <%= pgtype_array_type %>{Status: Null}
+		} else if len(value) == 0 {
+			*dst = <%= pgtype_array_type %>{Status: Present}
+		} else {
+			elements := make([]<%= pgtype_element_type %>, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]<%= pgtype_element_type %>, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil  {
+			*dst = <%= pgtype_array_type %>{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	<% end %>
+	<% end %>
+	case []<%= pgtype_element_type %>:
+		if value == nil {
+			*dst = <%= pgtype_array_type %>{Status: Null}
+		} else if len(value) == 0 {
+			*dst = <%= pgtype_array_type %>{Status: Present}
+		} else {
+			*dst = <%= pgtype_array_type %>{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status    : Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = <%= pgtype_array_type %>{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for <%= pgtype_array_type %>", src)
+		}
+		if elementsLength == 0 {
+			*dst = <%= pgtype_array_type %>{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to <%= pgtype_array_type %>", src)
+		}
+
+		*dst = <%= pgtype_array_type %> {
+			Elements:   make([]<%= pgtype_element_type %>, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]<%= pgtype_element_type %>, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil  {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to <%= pgtype_array_type %>, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to <%= pgtype_array_type %>, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -94,10 +131,11 @@ func (dst *<%= pgtype_array_type %>) setRecursive(value reflect.Value, index, di
 			break
 		}
 		
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -132,6 +170,21 @@ func (dst <%= pgtype_array_type %>) Get() interface{} {
 func (src *<%= pgtype_array_type %>) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1{
+			switch v := dst.(type) {
+			<% go_array_types.split(",").each do |t| %>
+			case *<%= t %>:
+				*v = make(<%= t %>, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+			<% end %>
+			}
+		}
+		
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -170,10 +223,12 @@ func (src *<%= pgtype_array_type %>) assignToRecursive(value reflect.Value, inde
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -191,11 +246,14 @@ func (src *<%= pgtype_array_type %>) assignToRecursive(value reflect.Value, inde
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr(){
 		return 0, errors.Errorf("cannot assign all values from <%= pgtype_array_type %>")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from <%= pgtype_array_type %>")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/typed_array_gen.sh
+++ b/typed_array_gen.sh
@@ -1,27 +1,27 @@
-erb pgtype_array_type=Int2Array pgtype_element_type=Int2 element_type_name=int2 text_null=NULL binary_format=true typed_array.go.erb > int2_array.go
-erb pgtype_array_type=Int4Array pgtype_element_type=Int4 element_type_name=int4 text_null=NULL binary_format=true typed_array.go.erb > int4_array.go
-erb pgtype_array_type=Int8Array pgtype_element_type=Int8 element_type_name=int8 text_null=NULL binary_format=true typed_array.go.erb > int8_array.go
-erb pgtype_array_type=BoolArray pgtype_element_type=Bool element_type_name=bool text_null=NULL binary_format=true typed_array.go.erb > bool_array.go
-erb pgtype_array_type=DateArray pgtype_element_type=Date element_type_name=date text_null=NULL binary_format=true typed_array.go.erb > date_array.go
-erb pgtype_array_type=TimestamptzArray pgtype_element_type=Timestamptz element_type_name=timestamptz text_null=NULL binary_format=true typed_array.go.erb > timestamptz_array.go
-erb pgtype_array_type=TstzrangeArray pgtype_element_type=Tstzrange element_type_name=tstzrange text_null=NULL binary_format=true typed_array.go.erb > tstzrange_array.go
-erb pgtype_array_type=TimestampArray pgtype_element_type=Timestamp element_type_name=timestamp text_null=NULL binary_format=true typed_array.go.erb > timestamp_array.go
-erb pgtype_array_type=Float4Array pgtype_element_type=Float4 element_type_name=float4 text_null=NULL binary_format=true typed_array.go.erb > float4_array.go
-erb pgtype_array_type=Float8Array pgtype_element_type=Float8 element_type_name=float8 text_null=NULL binary_format=true typed_array.go.erb > float8_array.go
-erb pgtype_array_type=InetArray pgtype_element_type=Inet element_type_name=inet text_null=NULL binary_format=true typed_array.go.erb > inet_array.go
-erb pgtype_array_type=MacaddrArray pgtype_element_type=Macaddr element_type_name=macaddr text_null=NULL binary_format=true typed_array.go.erb > macaddr_array.go
-erb pgtype_array_type=CIDRArray pgtype_element_type=CIDR element_type_name=cidr text_null=NULL binary_format=true typed_array.go.erb > cidr_array.go
-erb pgtype_array_type=TextArray pgtype_element_type=Text element_type_name=text text_null=NULL binary_format=true typed_array.go.erb > text_array.go
-erb pgtype_array_type=VarcharArray pgtype_element_type=Varchar element_type_name=varchar text_null=NULL binary_format=true typed_array.go.erb > varchar_array.go
-erb pgtype_array_type=BPCharArray pgtype_element_type=BPChar element_type_name=bpchar text_null=NULL binary_format=true typed_array.go.erb > bpchar_array.go
-erb pgtype_array_type=ByteaArray pgtype_element_type=Bytea element_type_name=bytea text_null=NULL binary_format=true typed_array.go.erb > bytea_array.go
-erb pgtype_array_type=ACLItemArray pgtype_element_type=ACLItem element_type_name=aclitem text_null=NULL binary_format=false typed_array.go.erb > aclitem_array.go
-erb pgtype_array_type=HstoreArray pgtype_element_type=Hstore element_type_name=hstore text_null=NULL binary_format=true typed_array.go.erb > hstore_array.go
-erb pgtype_array_type=NumericArray pgtype_element_type=Numeric element_type_name=numeric text_null=NULL binary_format=true typed_array.go.erb > numeric_array.go
-erb pgtype_array_type=UUIDArray pgtype_element_type=UUID element_type_name=uuid text_null=NULL binary_format=true typed_array.go.erb > uuid_array.go
-erb pgtype_array_type=JSONBArray pgtype_element_type=Text element_type_name=text text_null=NULL binary_format=true typed_array.go.erb > jsonb_array.go
+erb pgtype_array_type=Int2Array pgtype_element_type=Int2 go_array_types=[]int16,[]*int16,[]uint16,[]*uint16,[]int32,[]*int32,[]uint32,[]*uint32,[]int64,[]*int64,[]uint64,[]*uint64,[]int,[]*int,[]uint,[]*uint element_type_name=int2 text_null=NULL binary_format=true typed_array.go.erb > int2_array.go
+erb pgtype_array_type=Int4Array pgtype_element_type=Int4 go_array_types=[]int16,[]*int16,[]uint16,[]*uint16,[]int32,[]*int32,[]uint32,[]*uint32,[]int64,[]*int64,[]uint64,[]*uint64,[]int,[]*int,[]uint,[]*uint element_type_name=int4 text_null=NULL binary_format=true typed_array.go.erb > int4_array.go
+erb pgtype_array_type=Int8Array pgtype_element_type=Int8 go_array_types=[]int16,[]*int16,[]uint16,[]*uint16,[]int32,[]*int32,[]uint32,[]*uint32,[]int64,[]*int64,[]uint64,[]*uint64,[]int,[]*int,[]uint,[]*uint element_type_name=int8 text_null=NULL binary_format=true typed_array.go.erb > int8_array.go
+erb pgtype_array_type=BoolArray pgtype_element_type=Bool go_array_types=[]bool,[]*bool element_type_name=bool text_null=NULL binary_format=true typed_array.go.erb > bool_array.go
+erb pgtype_array_type=DateArray pgtype_element_type=Date go_array_types=[]time.Time,[]*time.Time element_type_name=date text_null=NULL binary_format=true typed_array.go.erb > date_array.go
+erb pgtype_array_type=TimestamptzArray pgtype_element_type=Timestamptz go_array_types=[]time.Time,[]*time.Time element_type_name=timestamptz text_null=NULL binary_format=true typed_array.go.erb > timestamptz_array.go
+erb pgtype_array_type=TstzrangeArray pgtype_element_type=Tstzrange go_array_types=[]Tstzrange element_type_name=tstzrange text_null=NULL binary_format=true typed_array.go.erb > tstzrange_array.go
+erb pgtype_array_type=TimestampArray pgtype_element_type=Timestamp go_array_types=[]time.Time,[]*time.Time element_type_name=timestamp text_null=NULL binary_format=true typed_array.go.erb > timestamp_array.go
+erb pgtype_array_type=Float4Array pgtype_element_type=Float4 go_array_types=[]float32,[]*float32 element_type_name=float4 text_null=NULL binary_format=true typed_array.go.erb > float4_array.go
+erb pgtype_array_type=Float8Array pgtype_element_type=Float8 go_array_types=[]float64,[]*float64 element_type_name=float8 text_null=NULL binary_format=true typed_array.go.erb > float8_array.go
+erb pgtype_array_type=InetArray pgtype_element_type=Inet go_array_types=[]*net.IPNet,[]net.IP,[]*net.IP element_type_name=inet text_null=NULL binary_format=true typed_array.go.erb > inet_array.go
+erb pgtype_array_type=MacaddrArray pgtype_element_type=Macaddr go_array_types=[]net.HardwareAddr,[]*net.HardwareAddr element_type_name=macaddr text_null=NULL binary_format=true typed_array.go.erb > macaddr_array.go
+erb pgtype_array_type=CIDRArray pgtype_element_type=CIDR go_array_types=[]*net.IPNet,[]net.IP,[]*net.IP element_type_name=cidr text_null=NULL binary_format=true typed_array.go.erb > cidr_array.go
+erb pgtype_array_type=TextArray pgtype_element_type=Text go_array_types=[]string,[]*string element_type_name=text text_null=NULL binary_format=true typed_array.go.erb > text_array.go
+erb pgtype_array_type=VarcharArray pgtype_element_type=Varchar go_array_types=[]string,[]*string element_type_name=varchar text_null=NULL binary_format=true typed_array.go.erb > varchar_array.go
+erb pgtype_array_type=BPCharArray pgtype_element_type=BPChar go_array_types=[]string,[]*string element_type_name=bpchar text_null=NULL binary_format=true typed_array.go.erb > bpchar_array.go
+erb pgtype_array_type=ByteaArray pgtype_element_type=Bytea go_array_types=[][]byte element_type_name=bytea text_null=NULL binary_format=true typed_array.go.erb > bytea_array.go
+erb pgtype_array_type=ACLItemArray pgtype_element_type=ACLItem go_array_types=[]string,[]*string element_type_name=aclitem text_null=NULL binary_format=false typed_array.go.erb > aclitem_array.go
+erb pgtype_array_type=HstoreArray pgtype_element_type=Hstore go_array_types=[]map[string]string element_type_name=hstore text_null=NULL binary_format=true typed_array.go.erb > hstore_array.go
+erb pgtype_array_type=NumericArray pgtype_element_type=Numeric go_array_types=[]float32,[]*float32,[]float64,[]*float64,[]int64,[]*int64,[]uint64,[]*uint64 element_type_name=numeric text_null=NULL binary_format=true typed_array.go.erb > numeric_array.go
+erb pgtype_array_type=UUIDArray pgtype_element_type=UUID go_array_types=[][16]byte,[][]byte,[]string,[]*string element_type_name=uuid text_null=NULL binary_format=true typed_array.go.erb > uuid_array.go
+erb pgtype_array_type=JSONBArray pgtype_element_type=Text go_array_types=[]string element_type_name=text text_null=NULL binary_format=true typed_array.go.erb > jsonb_array.go
 
 # While the binary format is theoretically possible it is only practical to use the text format.
-erb pgtype_array_type=EnumArray pgtype_element_type=GenericText text_null=NULL binary_format=false typed_array.go.erb > enum_array.go
+erb pgtype_array_type=EnumArray pgtype_element_type=GenericText go_array_types=[]string,[]*string text_null=NULL binary_format=false typed_array.go.erb > enum_array.go
 
 goimports -w *_array.go

--- a/typed_array_gen.sh
+++ b/typed_array_gen.sh
@@ -1,27 +1,27 @@
-erb pgtype_array_type=Int2Array pgtype_element_type=Int2 go_array_types=[]int16,[]*int16,[]uint16,[]*uint16,[]int32,[]*int32,[]uint32,[]*uint32,[]int64,[]*int64,[]uint64,[]*uint64,[]int,[]*int,[]uint,[]*uint element_type_name=int2 text_null=NULL binary_format=true typed_array.go.erb > int2_array.go
-erb pgtype_array_type=Int4Array pgtype_element_type=Int4 go_array_types=[]int16,[]*int16,[]uint16,[]*uint16,[]int32,[]*int32,[]uint32,[]*uint32,[]int64,[]*int64,[]uint64,[]*uint64,[]int,[]*int,[]uint,[]*uint element_type_name=int4 text_null=NULL binary_format=true typed_array.go.erb > int4_array.go
-erb pgtype_array_type=Int8Array pgtype_element_type=Int8 go_array_types=[]int16,[]*int16,[]uint16,[]*uint16,[]int32,[]*int32,[]uint32,[]*uint32,[]int64,[]*int64,[]uint64,[]*uint64,[]int,[]*int,[]uint,[]*uint element_type_name=int8 text_null=NULL binary_format=true typed_array.go.erb > int8_array.go
-erb pgtype_array_type=BoolArray pgtype_element_type=Bool go_array_types=[]bool,[]*bool element_type_name=bool text_null=NULL binary_format=true typed_array.go.erb > bool_array.go
-erb pgtype_array_type=DateArray pgtype_element_type=Date go_array_types=[]time.Time,[]*time.Time element_type_name=date text_null=NULL binary_format=true typed_array.go.erb > date_array.go
-erb pgtype_array_type=TimestamptzArray pgtype_element_type=Timestamptz go_array_types=[]time.Time,[]*time.Time element_type_name=timestamptz text_null=NULL binary_format=true typed_array.go.erb > timestamptz_array.go
-erb pgtype_array_type=TstzrangeArray pgtype_element_type=Tstzrange go_array_types=[]Tstzrange element_type_name=tstzrange text_null=NULL binary_format=true typed_array.go.erb > tstzrange_array.go
-erb pgtype_array_type=TimestampArray pgtype_element_type=Timestamp go_array_types=[]time.Time,[]*time.Time element_type_name=timestamp text_null=NULL binary_format=true typed_array.go.erb > timestamp_array.go
-erb pgtype_array_type=Float4Array pgtype_element_type=Float4 go_array_types=[]float32,[]*float32 element_type_name=float4 text_null=NULL binary_format=true typed_array.go.erb > float4_array.go
-erb pgtype_array_type=Float8Array pgtype_element_type=Float8 go_array_types=[]float64,[]*float64 element_type_name=float8 text_null=NULL binary_format=true typed_array.go.erb > float8_array.go
-erb pgtype_array_type=InetArray pgtype_element_type=Inet go_array_types=[]*net.IPNet,[]net.IP,[]*net.IP element_type_name=inet text_null=NULL binary_format=true typed_array.go.erb > inet_array.go
-erb pgtype_array_type=MacaddrArray pgtype_element_type=Macaddr go_array_types=[]net.HardwareAddr,[]*net.HardwareAddr element_type_name=macaddr text_null=NULL binary_format=true typed_array.go.erb > macaddr_array.go
-erb pgtype_array_type=CIDRArray pgtype_element_type=CIDR go_array_types=[]*net.IPNet,[]net.IP,[]*net.IP element_type_name=cidr text_null=NULL binary_format=true typed_array.go.erb > cidr_array.go
-erb pgtype_array_type=TextArray pgtype_element_type=Text go_array_types=[]string,[]*string element_type_name=text text_null=NULL binary_format=true typed_array.go.erb > text_array.go
-erb pgtype_array_type=VarcharArray pgtype_element_type=Varchar go_array_types=[]string,[]*string element_type_name=varchar text_null=NULL binary_format=true typed_array.go.erb > varchar_array.go
-erb pgtype_array_type=BPCharArray pgtype_element_type=BPChar go_array_types=[]string,[]*string element_type_name=bpchar text_null=NULL binary_format=true typed_array.go.erb > bpchar_array.go
-erb pgtype_array_type=ByteaArray pgtype_element_type=Bytea go_array_types=[][]byte element_type_name=bytea text_null=NULL binary_format=true typed_array.go.erb > bytea_array.go
-erb pgtype_array_type=ACLItemArray pgtype_element_type=ACLItem go_array_types=[]string,[]*string element_type_name=aclitem text_null=NULL binary_format=false typed_array.go.erb > aclitem_array.go
-erb pgtype_array_type=HstoreArray pgtype_element_type=Hstore go_array_types=[]map[string]string element_type_name=hstore text_null=NULL binary_format=true typed_array.go.erb > hstore_array.go
-erb pgtype_array_type=NumericArray pgtype_element_type=Numeric go_array_types=[]float32,[]*float32,[]float64,[]*float64,[]int64,[]*int64,[]uint64,[]*uint64 element_type_name=numeric text_null=NULL binary_format=true typed_array.go.erb > numeric_array.go
-erb pgtype_array_type=UUIDArray pgtype_element_type=UUID go_array_types=[][16]byte,[][]byte,[]string,[]*string element_type_name=uuid text_null=NULL binary_format=true typed_array.go.erb > uuid_array.go
-erb pgtype_array_type=JSONBArray pgtype_element_type=Text go_array_types=[]string element_type_name=text text_null=NULL binary_format=true typed_array.go.erb > jsonb_array.go
+erb pgtype_array_type=Int2Array pgtype_element_type=Int2 element_type_name=int2 text_null=NULL binary_format=true typed_array.go.erb > int2_array.go
+erb pgtype_array_type=Int4Array pgtype_element_type=Int4 element_type_name=int4 text_null=NULL binary_format=true typed_array.go.erb > int4_array.go
+erb pgtype_array_type=Int8Array pgtype_element_type=Int8 element_type_name=int8 text_null=NULL binary_format=true typed_array.go.erb > int8_array.go
+erb pgtype_array_type=BoolArray pgtype_element_type=Bool element_type_name=bool text_null=NULL binary_format=true typed_array.go.erb > bool_array.go
+erb pgtype_array_type=DateArray pgtype_element_type=Date element_type_name=date text_null=NULL binary_format=true typed_array.go.erb > date_array.go
+erb pgtype_array_type=TimestamptzArray pgtype_element_type=Timestamptz element_type_name=timestamptz text_null=NULL binary_format=true typed_array.go.erb > timestamptz_array.go
+erb pgtype_array_type=TstzrangeArray pgtype_element_type=Tstzrange element_type_name=tstzrange text_null=NULL binary_format=true typed_array.go.erb > tstzrange_array.go
+erb pgtype_array_type=TimestampArray pgtype_element_type=Timestamp element_type_name=timestamp text_null=NULL binary_format=true typed_array.go.erb > timestamp_array.go
+erb pgtype_array_type=Float4Array pgtype_element_type=Float4 element_type_name=float4 text_null=NULL binary_format=true typed_array.go.erb > float4_array.go
+erb pgtype_array_type=Float8Array pgtype_element_type=Float8 element_type_name=float8 text_null=NULL binary_format=true typed_array.go.erb > float8_array.go
+erb pgtype_array_type=InetArray pgtype_element_type=Inet element_type_name=inet text_null=NULL binary_format=true typed_array.go.erb > inet_array.go
+erb pgtype_array_type=MacaddrArray pgtype_element_type=Macaddr element_type_name=macaddr text_null=NULL binary_format=true typed_array.go.erb > macaddr_array.go
+erb pgtype_array_type=CIDRArray pgtype_element_type=CIDR element_type_name=cidr text_null=NULL binary_format=true typed_array.go.erb > cidr_array.go
+erb pgtype_array_type=TextArray pgtype_element_type=Text element_type_name=text text_null=NULL binary_format=true typed_array.go.erb > text_array.go
+erb pgtype_array_type=VarcharArray pgtype_element_type=Varchar element_type_name=varchar text_null=NULL binary_format=true typed_array.go.erb > varchar_array.go
+erb pgtype_array_type=BPCharArray pgtype_element_type=BPChar element_type_name=bpchar text_null=NULL binary_format=true typed_array.go.erb > bpchar_array.go
+erb pgtype_array_type=ByteaArray pgtype_element_type=Bytea element_type_name=bytea text_null=NULL binary_format=true typed_array.go.erb > bytea_array.go
+erb pgtype_array_type=ACLItemArray pgtype_element_type=ACLItem element_type_name=aclitem text_null=NULL binary_format=false typed_array.go.erb > aclitem_array.go
+erb pgtype_array_type=HstoreArray pgtype_element_type=Hstore element_type_name=hstore text_null=NULL binary_format=true typed_array.go.erb > hstore_array.go
+erb pgtype_array_type=NumericArray pgtype_element_type=Numeric element_type_name=numeric text_null=NULL binary_format=true typed_array.go.erb > numeric_array.go
+erb pgtype_array_type=UUIDArray pgtype_element_type=UUID element_type_name=uuid text_null=NULL binary_format=true typed_array.go.erb > uuid_array.go
+erb pgtype_array_type=JSONBArray pgtype_element_type=Text element_type_name=text text_null=NULL binary_format=true typed_array.go.erb > jsonb_array.go
 
 # While the binary format is theoretically possible it is only practical to use the text format.
-erb pgtype_array_type=EnumArray pgtype_element_type=GenericText go_array_types=[]string,[]*string text_null=NULL binary_format=false typed_array.go.erb > enum_array.go
+erb pgtype_array_type=EnumArray pgtype_element_type=GenericText text_null=NULL binary_format=false typed_array.go.erb > enum_array.go
 
 goimports -w *_array.go

--- a/uuid_array.go
+++ b/uuid_array.go
@@ -31,56 +31,148 @@ func (dst *UUIDArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = UUIDArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for UUIDArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = UUIDArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to UUIDArray", src)
-	}
-
-	*dst = UUIDArray{
-		Elements:   make([]UUID, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case [][16]byte:
+		if value == nil {
+			*dst = UUIDArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = UUIDArray{Status: Present}
+		} else {
+			elements := make([]UUID, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]UUID, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = UUIDArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case [][]byte:
+		if value == nil {
+			*dst = UUIDArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = UUIDArray{Status: Present}
+		} else {
+			elements := make([]UUID, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = UUIDArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []string:
+		if value == nil {
+			*dst = UUIDArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = UUIDArray{Status: Present}
+		} else {
+			elements := make([]UUID, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = UUIDArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*string:
+		if value == nil {
+			*dst = UUIDArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = UUIDArray{Status: Present}
+		} else {
+			elements := make([]UUID, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = UUIDArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []UUID:
+		if value == nil {
+			*dst = UUIDArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = UUIDArray{Status: Present}
+		} else {
+			*dst = UUIDArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = UUIDArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for UUIDArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = UUIDArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to UUIDArray", src)
+		}
+
+		*dst = UUIDArray{
+			Elements:   make([]UUID, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]UUID, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to UUIDArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to UUIDArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +187,11 @@ func (dst *UUIDArray) setRecursive(value reflect.Value, index, dimension int) (i
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +226,48 @@ func (dst UUIDArray) Get() interface{} {
 func (src *UUIDArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[][16]byte:
+				*v = make([][16]byte, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[][]byte:
+				*v = make([][]byte, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]string:
+				*v = make([]string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*string:
+				*v = make([]*string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +306,12 @@ func (src *UUIDArray) assignToRecursive(value reflect.Value, index, dimension in
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +329,14 @@ func (src *UUIDArray) assignToRecursive(value reflect.Value, index, dimension in
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from UUIDArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from UUIDArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/uuid_array_test.go
+++ b/uuid_array_test.go
@@ -123,6 +123,78 @@ func TestUUIDArraySet(t *testing.T) {
 			source: ([]string)(nil),
 			result: pgtype.UUIDArray{Status: pgtype.Null},
 		},
+		{
+			source: [][][16]byte{{
+				{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+				{{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}}},
+			result: pgtype.UUIDArray{
+				Elements: []pgtype.UUID{
+					{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+					{Bytes: [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]string{
+				{{{
+					"00010203-0405-0607-0809-0a0b0c0d0e0f",
+					"10111213-1415-1617-1819-1a1b1c1d1e1f",
+					"20212223-2425-2627-2829-2a2b2c2d2e2f"}}},
+				{{{
+					"30313233-3435-3637-3839-3a3b3c3d3e3f",
+					"40414243-4445-4647-4849-4a4b4c4d4e4f",
+					"50515253-5455-5657-5859-5a5b5c5d5e5f"}}}},
+			result: pgtype.UUIDArray{
+				Elements: []pgtype.UUID{
+					{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+					{Bytes: [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, Status: pgtype.Present},
+					{Bytes: [16]byte{32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47}, Status: pgtype.Present},
+					{Bytes: [16]byte{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63}, Status: pgtype.Present},
+					{Bytes: [16]byte{64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79}, Status: pgtype.Present},
+					{Bytes: [16]byte{80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1][16]byte{{
+				{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+				{{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}}},
+			result: pgtype.UUIDArray{
+				Elements: []pgtype.UUID{
+					{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+					{Bytes: [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]string{
+				{{{
+					"00010203-0405-0607-0809-0a0b0c0d0e0f",
+					"10111213-1415-1617-1819-1a1b1c1d1e1f",
+					"20212223-2425-2627-2829-2a2b2c2d2e2f"}}},
+				{{{
+					"30313233-3435-3637-3839-3a3b3c3d3e3f",
+					"40414243-4445-4647-4849-4a4b4c4d4e4f",
+					"50515253-5455-5657-5859-5a5b5c5d5e5f"}}}},
+			result: pgtype.UUIDArray{
+				Elements: []pgtype.UUID{
+					{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+					{Bytes: [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, Status: pgtype.Present},
+					{Bytes: [16]byte{32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47}, Status: pgtype.Present},
+					{Bytes: [16]byte{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63}, Status: pgtype.Present},
+					{Bytes: [16]byte{64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79}, Status: pgtype.Present},
+					{Bytes: [16]byte{80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -142,6 +214,10 @@ func TestUUIDArrayAssignTo(t *testing.T) {
 	var byteArraySlice [][16]byte
 	var byteSliceSlice [][]byte
 	var stringSlice []string
+	var byteArraySliceDim2 [][][16]byte
+	var stringSliceDim4 [][][][]string
+	var byteArrayDim2 [2][1][16]byte
+	var stringArrayDim4 [2][1][1][3]string
 
 	simpleTests := []struct {
 		src      pgtype.UUIDArray
@@ -189,6 +265,82 @@ func TestUUIDArrayAssignTo(t *testing.T) {
 			src:      pgtype.UUIDArray{Status: pgtype.Null},
 			dst:      &stringSlice,
 			expected: ([]string)(nil),
+		},
+		{
+			src: pgtype.UUIDArray{
+				Elements: []pgtype.UUID{
+					{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+					{Bytes: [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &byteArraySliceDim2,
+			expected: [][][16]byte{{
+				{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+				{{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}}},
+		},
+		{
+			src: pgtype.UUIDArray{
+				Elements: []pgtype.UUID{
+					{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+					{Bytes: [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, Status: pgtype.Present},
+					{Bytes: [16]byte{32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47}, Status: pgtype.Present},
+					{Bytes: [16]byte{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63}, Status: pgtype.Present},
+					{Bytes: [16]byte{64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79}, Status: pgtype.Present},
+					{Bytes: [16]byte{80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &stringSliceDim4,
+			expected: [][][][]string{
+				{{{
+					"00010203-0405-0607-0809-0a0b0c0d0e0f",
+					"10111213-1415-1617-1819-1a1b1c1d1e1f",
+					"20212223-2425-2627-2829-2a2b2c2d2e2f"}}},
+				{{{
+					"30313233-3435-3637-3839-3a3b3c3d3e3f",
+					"40414243-4445-4647-4849-4a4b4c4d4e4f",
+					"50515253-5455-5657-5859-5a5b5c5d5e5f"}}}},
+		},
+		{
+			src: pgtype.UUIDArray{
+				Elements: []pgtype.UUID{
+					{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+					{Bytes: [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &byteArrayDim2,
+			expected: [2][1][16]byte{{
+				{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+				{{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}}},
+		},
+		{
+			src: pgtype.UUIDArray{
+				Elements: []pgtype.UUID{
+					{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+					{Bytes: [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, Status: pgtype.Present},
+					{Bytes: [16]byte{32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47}, Status: pgtype.Present},
+					{Bytes: [16]byte{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63}, Status: pgtype.Present},
+					{Bytes: [16]byte{64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79}, Status: pgtype.Present},
+					{Bytes: [16]byte{80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95}, Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst: &stringArrayDim4,
+			expected: [2][1][1][3]string{
+				{{{
+					"00010203-0405-0607-0809-0a0b0c0d0e0f",
+					"10111213-1415-1617-1819-1a1b1c1d1e1f",
+					"20212223-2425-2627-2829-2a2b2c2d2e2f"}}},
+				{{{
+					"30313233-3435-3637-3839-3a3b3c3d3e3f",
+					"40414243-4445-4647-4849-4a4b4c4d4e4f",
+					"50515253-5455-5657-5859-5a5b5c5d5e5f"}}}},
 		},
 	}
 

--- a/varchar_array.go
+++ b/varchar_array.go
@@ -5,6 +5,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"reflect"
 
 	"github.com/jackc/pgio"
 	errors "golang.org/x/xerrors"
@@ -30,66 +31,92 @@ func (dst *VarcharArray) Set(src interface{}) error {
 		}
 	}
 
-	switch value := src.(type) {
+	value := reflect.ValueOf(src)
+	if !value.IsValid() || value.IsZero() {
+		*dst = VarcharArray{Status: Null}
+		return nil
+	}
 
-	case []string:
-		if value == nil {
-			*dst = VarcharArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = VarcharArray{Status: Present}
-		} else {
-			elements := make([]Varchar, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = VarcharArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []*string:
-		if value == nil {
-			*dst = VarcharArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = VarcharArray{Status: Present}
-		} else {
-			elements := make([]Varchar, len(value))
-			for i := range value {
-				if err := elements[i].Set(value[i]); err != nil {
-					return err
-				}
-			}
-			*dst = VarcharArray{
-				Elements:   elements,
-				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-
-	case []Varchar:
-		if value == nil {
-			*dst = VarcharArray{Status: Null}
-		} else if len(value) == 0 {
-			*dst = VarcharArray{Status: Present}
-		} else {
-			*dst = VarcharArray{
-				Elements:   value,
-				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
-				Status:     Present,
-			}
-		}
-	default:
+	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
+	if !ok {
+		return errors.Errorf("cannot find dimensions of %v for VarcharArray", src)
+	}
+	if elementsLength == 0 {
+		*dst = VarcharArray{Status: Present}
+		return nil
+	}
+	if len(dimensions) == 0 {
 		if originalSrc, ok := underlyingSliceType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return errors.Errorf("cannot convert %v to VarcharArray", value)
+		return errors.Errorf("cannot convert %v to VarcharArray", src)
+	}
+
+	*dst = VarcharArray{
+		Elements:   make([]Varchar, elementsLength),
+		Dimensions: dimensions,
+		Status:     Present,
+	}
+	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
+	if err != nil {
+		// Maybe the target was one dimension too far, try again:
+		if len(dst.Dimensions) > 1 {
+			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+			elementsLength = 0
+			for _, dim := range dst.Dimensions {
+				if elementsLength == 0 {
+					elementsLength = int(dim.Length)
+				} else {
+					elementsLength *= int(dim.Length)
+				}
+			}
+			dst.Elements = make([]Varchar, elementsLength)
+			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	if elementCount != len(dst.Elements) {
+		return errors.Errorf("cannot convert %v to VarcharArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
 	}
 
 	return nil
+}
+
+func (dst *VarcharArray) setRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch value.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(dst.Dimensions) == dimension {
+			break
+		}
+
+		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+		}
+		for i := 0; i < value.Len(); i++ {
+			var err error
+			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if !value.CanInterface() {
+		return 0, errors.Errorf("cannot convert all values to VarcharArray")
+	}
+	if err := dst.Elements[index].Set(value.Interface()); err != nil {
+		return 0, errors.Errorf("%v in VarcharArray", err)
+	}
+	index++
+
+	return index, nil
 }
 
 func (dst VarcharArray) Get() interface{} {
@@ -106,37 +133,74 @@ func (dst VarcharArray) Get() interface{} {
 func (src *VarcharArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
-		switch v := dst.(type) {
-
-		case *[]string:
-			*v = make([]string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		case *[]*string:
-			*v = make([]*string, len(src.Elements))
-			for i := range src.Elements {
-				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
-					return err
-				}
-			}
-			return nil
-
-		default:
+		value := reflect.ValueOf(dst)
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		if !value.CanSet() {
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}
 			return errors.Errorf("unable to assign to %T", dst)
 		}
+
+		elementCount, err := src.assignToRecursive(value, 0, 0)
+		if err != nil {
+			return err
+		}
+		if elementCount != len(src.Elements) {
+			return errors.Errorf("cannot assign %v, needed to assign %d elements, but only assigned %d", dst, len(src.Elements), elementCount)
+		}
+
+		return nil
 	case Null:
 		return NullAssignTo(dst)
 	}
 
 	return errors.Errorf("cannot decode %#v into %T", src, dst)
+}
+
+func (src *VarcharArray) assignToRecursive(value reflect.Value, index, dimension int) (int, error) {
+	switch kind := value.Kind(); kind {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		if len(src.Dimensions) == dimension {
+			break
+		}
+
+		length := int(src.Dimensions[dimension].Length)
+		if reflect.Array == kind {
+			if value.Type().Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			}
+			value.Set(reflect.New(value.Type()).Elem())
+		} else {
+			value.Set(reflect.MakeSlice(value.Type(), length, length))
+		}
+
+		var err error
+		for i := 0; i < length; i++ {
+			index, err = src.assignToRecursive(value.Index(i), index, dimension+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		return index, nil
+	}
+	if len(src.Dimensions) != dimension {
+		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
+	}
+	if !value.CanAddr() || !value.Addr().CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from VarcharArray")
+	}
+	err := src.Elements[index].AssignTo(value.Addr().Interface())
+	if err != nil {
+		return 0, err
+	}
+	index++
+	return index, nil
 }
 
 func (dst *VarcharArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/varchar_array.go
+++ b/varchar_array.go
@@ -31,56 +31,110 @@ func (dst *VarcharArray) Set(src interface{}) error {
 		}
 	}
 
-	value := reflect.ValueOf(src)
-	if !value.IsValid() || value.IsZero() {
-		*dst = VarcharArray{Status: Null}
-		return nil
-	}
+	switch value := src.(type) {
 
-	dimensions, elementsLength, ok := findDimensionsFromValue(reflect.ValueOf(src), nil, 0)
-	if !ok {
-		return errors.Errorf("cannot find dimensions of %v for VarcharArray", src)
-	}
-	if elementsLength == 0 {
-		*dst = VarcharArray{Status: Present}
-		return nil
-	}
-	if len(dimensions) == 0 {
-		if originalSrc, ok := underlyingSliceType(src); ok {
-			return dst.Set(originalSrc)
-		}
-		return errors.Errorf("cannot convert %v to VarcharArray", src)
-	}
-
-	*dst = VarcharArray{
-		Elements:   make([]Varchar, elementsLength),
-		Dimensions: dimensions,
-		Status:     Present,
-	}
-	elementCount, err := dst.setRecursive(reflect.ValueOf(src), 0, 0)
-	if err != nil {
-		// Maybe the target was one dimension too far, try again:
-		if len(dst.Dimensions) > 1 {
-			dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
-			elementsLength = 0
-			for _, dim := range dst.Dimensions {
-				if elementsLength == 0 {
-					elementsLength = int(dim.Length)
-				} else {
-					elementsLength *= int(dim.Length)
+	case []string:
+		if value == nil {
+			*dst = VarcharArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = VarcharArray{Status: Present}
+		} else {
+			elements := make([]Varchar, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
 				}
 			}
-			dst.Elements = make([]Varchar, elementsLength)
-			elementCount, err = dst.setRecursive(reflect.ValueOf(src), 0, 0)
-			if err != nil {
+			*dst = VarcharArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []*string:
+		if value == nil {
+			*dst = VarcharArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = VarcharArray{Status: Present}
+		} else {
+			elements := make([]Varchar, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = VarcharArray{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []Varchar:
+		if value == nil {
+			*dst = VarcharArray{Status: Null}
+		} else if len(value) == 0 {
+			*dst = VarcharArray{Status: Present}
+		} else {
+			*dst = VarcharArray{
+				Elements:   value,
+				Dimensions: []ArrayDimension{{Length: int32(len(value)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+	default:
+		reflectedValue := reflect.ValueOf(src)
+		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
+			*dst = VarcharArray{Status: Null}
+			return nil
+		}
+
+		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
+		if !ok {
+			return errors.Errorf("cannot find dimensions of %v for VarcharArray", src)
+		}
+		if elementsLength == 0 {
+			*dst = VarcharArray{Status: Present}
+			return nil
+		}
+		if len(dimensions) == 0 {
+			if originalSrc, ok := underlyingSliceType(src); ok {
+				return dst.Set(originalSrc)
+			}
+			return errors.Errorf("cannot convert %v to VarcharArray", src)
+		}
+
+		*dst = VarcharArray{
+			Elements:   make([]Varchar, elementsLength),
+			Dimensions: dimensions,
+			Status:     Present,
+		}
+		elementCount, err := dst.setRecursive(reflectedValue, 0, 0)
+		if err != nil {
+			// Maybe the target was one dimension too far, try again:
+			if len(dst.Dimensions) > 1 {
+				dst.Dimensions = dst.Dimensions[:len(dst.Dimensions)-1]
+				elementsLength = 0
+				for _, dim := range dst.Dimensions {
+					if elementsLength == 0 {
+						elementsLength = int(dim.Length)
+					} else {
+						elementsLength *= int(dim.Length)
+					}
+				}
+				dst.Elements = make([]Varchar, elementsLength)
+				elementCount, err = dst.setRecursive(reflectedValue, 0, 0)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
-		} else {
-			return err
 		}
-	}
-	if elementCount != len(dst.Elements) {
-		return errors.Errorf("cannot convert %v to VarcharArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		if elementCount != len(dst.Elements) {
+			return errors.Errorf("cannot convert %v to VarcharArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+		}
 	}
 
 	return nil
@@ -95,10 +149,11 @@ func (dst *VarcharArray) setRecursive(value reflect.Value, index, dimension int)
 			break
 		}
 
-		if int32(value.Len()) != dst.Dimensions[dimension].Length {
+		valueLen := value.Len()
+		if int32(valueLen) != dst.Dimensions[dimension].Length {
 			return 0, errors.Errorf("multidimensional arrays must have array expressions with matching dimensions")
 		}
-		for i := 0; i < value.Len(); i++ {
+		for i := 0; i < valueLen; i++ {
 			var err error
 			index, err = dst.setRecursive(value.Index(i), index, dimension+1)
 			if err != nil {
@@ -133,6 +188,30 @@ func (dst VarcharArray) Get() interface{} {
 func (src *VarcharArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Dimensions) == 1 {
+			switch v := dst.(type) {
+
+			case *[]string:
+				*v = make([]string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			case *[]*string:
+				*v = make([]*string, len(src.Elements))
+				for i := range src.Elements {
+					if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+						return err
+					}
+				}
+				return nil
+
+			}
+		}
+
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -171,10 +250,12 @@ func (src *VarcharArray) assignToRecursive(value reflect.Value, index, dimension
 
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
-			if value.Type().Len() != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, value.Type(), value.Type().Len())
+			typ := value.Type()
+			typLen := typ.Len()
+			if typLen != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
 			}
-			value.Set(reflect.New(value.Type()).Elem())
+			value.Set(reflect.New(typ).Elem())
 		} else {
 			value.Set(reflect.MakeSlice(value.Type(), length, length))
 		}
@@ -192,11 +273,14 @@ func (src *VarcharArray) assignToRecursive(value reflect.Value, index, dimension
 	if len(src.Dimensions) != dimension {
 		return 0, errors.Errorf("incorrect dimensions, expected %d, found %d", len(src.Dimensions), dimension)
 	}
-	if !value.CanAddr() || !value.Addr().CanInterface() {
+	if !value.CanAddr() {
 		return 0, errors.Errorf("cannot assign all values from VarcharArray")
 	}
-	err := src.Elements[index].AssignTo(value.Addr().Interface())
-	if err != nil {
+	addr := value.Addr()
+	if !addr.CanInterface() {
+		return 0, errors.Errorf("cannot assign all values from VarcharArray")
+	}
+	if err := src.Elements[index].AssignTo(addr.Interface()); err != nil {
 		return 0, err
 	}
 	index++

--- a/varchar_array.go
+++ b/varchar_array.go
@@ -31,6 +31,7 @@ func (dst *VarcharArray) Set(src interface{}) error {
 		}
 	}
 
+	// Attempt to match to select common types:
 	switch value := src.(type) {
 
 	case []string:
@@ -84,6 +85,9 @@ func (dst *VarcharArray) Set(src interface{}) error {
 			}
 		}
 	default:
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		reflectedValue := reflect.ValueOf(src)
 		if !reflectedValue.IsValid() || reflectedValue.IsZero() {
 			*dst = VarcharArray{Status: Null}
@@ -189,6 +193,7 @@ func (src *VarcharArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
 		if len(src.Dimensions) == 1 {
+			// Attempt to match to select common types:
 			switch v := dst.(type) {
 
 			case *[]string:
@@ -212,6 +217,9 @@ func (src *VarcharArray) AssignTo(dst interface{}) error {
 			}
 		}
 
+		// Fallback to reflection if an optimised match was not found.
+		// The reflection is necessary for arrays and multidimensional slices,
+		// but it comes with a 20-50% performance penalty for large arrays/slices
 		value := reflect.ValueOf(dst)
 		if value.Kind() == reflect.Ptr {
 			value = value.Elem()
@@ -251,9 +259,8 @@ func (src *VarcharArray) assignToRecursive(value reflect.Value, index, dimension
 		length := int(src.Dimensions[dimension].Length)
 		if reflect.Array == kind {
 			typ := value.Type()
-			typLen := typ.Len()
-			if typLen != length {
-				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typLen)
+			if typ.Len() != length {
+				return 0, errors.Errorf("expected size %d array, but %s has size %d array", length, typ, typ.Len())
 			}
 			value.Set(reflect.New(typ).Elem())
 		} else {

--- a/varchar_array_test.go
+++ b/varchar_array_test.go
@@ -68,6 +68,54 @@ func TestVarcharArraySet(t *testing.T) {
 			source: (([]string)(nil)),
 			result: pgtype.VarcharArray{Status: pgtype.Null},
 		},
+		{
+			source: [][]string{{"foo"}, {"bar"}},
+			result: pgtype.VarcharArray{
+				Elements:   []pgtype.Varchar{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [][][][]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+			result: pgtype.VarcharArray{
+				Elements: []pgtype.Varchar{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
+		{
+			source: [2][1]string{{"foo"}, {"bar"}},
+			result: pgtype.VarcharArray{
+				Elements:   []pgtype.Varchar{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: [2][1][1][3]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+			result: pgtype.VarcharArray{
+				Elements: []pgtype.Varchar{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+		},
 	}
 
 	for i, tt := range successfulTests {
@@ -87,6 +135,10 @@ func TestVarcharArrayAssignTo(t *testing.T) {
 	var stringSlice []string
 	type _stringSlice []string
 	var namedStringSlice _stringSlice
+	var stringSliceDim2 [][]string
+	var stringSliceDim4 [][][][]string
+	var stringArrayDim2 [2][1]string
+	var stringArrayDim4 [2][1][1][3]string
 
 	simpleTests := []struct {
 		src      pgtype.VarcharArray
@@ -116,6 +168,58 @@ func TestVarcharArrayAssignTo(t *testing.T) {
 			dst:      &stringSlice,
 			expected: (([]string)(nil)),
 		},
+		{
+			src: pgtype.VarcharArray{
+				Elements:   []pgtype.Varchar{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &stringSliceDim2,
+			expected: [][]string{{"foo"}, {"bar"}},
+		},
+		{
+			src: pgtype.VarcharArray{
+				Elements: []pgtype.Varchar{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &stringSliceDim4,
+			expected: [][][][]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+		},
+		{
+			src: pgtype.VarcharArray{
+				Elements:   []pgtype.Varchar{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst:      &stringArrayDim2,
+			expected: [2][1]string{{"foo"}, {"bar"}},
+		},
+		{
+			src: pgtype.VarcharArray{
+				Elements: []pgtype.Varchar{
+					{String: "foo", Status: pgtype.Present},
+					{String: "bar", Status: pgtype.Present},
+					{String: "baz", Status: pgtype.Present},
+					{String: "wibble", Status: pgtype.Present},
+					{String: "wobble", Status: pgtype.Present},
+					{String: "wubble", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{
+					{LowerBound: 1, Length: 2},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 1},
+					{LowerBound: 1, Length: 3}},
+				Status: pgtype.Present},
+			dst:      &stringArrayDim4,
+			expected: [2][1][1][3]string{{{{"foo", "bar", "baz"}}}, {{{"wibble", "wobble", "wubble"}}}},
+		},
 	}
 
 	for i, tt := range simpleTests {
@@ -140,6 +244,27 @@ func TestVarcharArrayAssignTo(t *testing.T) {
 				Status:     pgtype.Present,
 			},
 			dst: &stringSlice,
+		},
+		{
+			src: pgtype.VarcharArray{
+				Elements:   []pgtype.Varchar{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &stringArrayDim2,
+		},
+		{
+			src: pgtype.VarcharArray{
+				Elements:   []pgtype.Varchar{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}, {LowerBound: 1, Length: 2}},
+				Status:     pgtype.Present},
+			dst: &stringSlice,
+		},
+		{
+			src: pgtype.VarcharArray{
+				Elements:   []pgtype.Varchar{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+			dst: &stringArrayDim4,
 		},
 	}
 


### PR DESCRIPTION
This PR adds support for multidimensional arrays and slices (https://www.postgresql.org/docs/current/arrays.html).

### Previously (/Motivation):
- Only single dimensional slices were supported.
- The single dimensional slice types were hard-coded.
- If a new type conversion was added to the array's element (e.g. `Int4`), this would not be automatically supported by the array itself (e.g. `Int4Array`) as it relies on a manual update.
- Arrays were not supported. This was likely due to the hard-coded slice types and it is not possible to hard-code all possible array sizes.

### New functionality:
- Multidimensional slices are now supported.
- Arrays are now also supported, including multidimensional arrays.
- Adds new test cases for multidimensional arrays and slices.
- New type conversions for an array are automatically supported when the array's element gains new type conversion support.

### Maintenance improvements:
- Removes hard-coded type conversions for arrays (e.g. `Int4Array`). Instead each array now relies on its element's (e.g. `Int4`) type conversion support.
- Simplifies `typed_array_gen.sh` generator script by removing the hard-coded single-dimensional types for arrays.

### This PR is fully backwards compatible:
- All previous test cases are unmodified and passed.
- Only small changes to the code:
  - Two functions were modified (`Set` and `AssignTo`) in `typed_array.go.erb` with the addition of two new unexported auxiliary functions for recursion.
  - One new unexported auxiliary function in `array.go` file
  - `go_array_types` parameter removal in `typed_array_gen.sh`
  - Additional tests for each (PG-)array to test the new multidimensional support for (Go-)arrays and slices.