### PR TITLE
Support setting infinite timestamps

### DIFF
--- a/timestamp.go
+++ b/timestamp.go
@@ -46,6 +46,8 @@ func (dst *Timestamp) Set(src interface{}) error {
 		} else {
 			return dst.Set(*value)
 		}
+	case InfinityModifier:
+		*dst = Timestamp{InfinityModifier: value, Status: Present}
 	default:
 		if originalSrc, ok := underlyingTimeType(src); ok {
 			return dst.Set(originalSrc)

--- a/timestamp_test.go
+++ b/timestamp_test.go
@@ -92,6 +92,8 @@ func TestTimestampSet(t *testing.T) {
 		{source: time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC), result: pgtype.Timestamp{Time: time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
 		{source: time.Date(2015, 1, 1, 0, 0, 0, 0, time.Local), result: pgtype.Timestamp{Time: time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
 		{source: _time(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)), result: pgtype.Timestamp{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+		{source: pgtype.Infinity, result: pgtype.Timestamp{InfinityModifier: pgtype.Infinity, Status: pgtype.Present}},
+		{source: pgtype.NegativeInfinity, result: pgtype.Timestamp{InfinityModifier: pgtype.NegativeInfinity, Status: pgtype.Present}},
 	}
 
 	for i, tt := range successfulTests {

--- a/timestamptz.go
+++ b/timestamptz.go
@@ -48,6 +48,8 @@ func (dst *Timestamptz) Set(src interface{}) error {
 		} else {
 			return dst.Set(*value)
 		}
+	case InfinityModifier:
+		*dst = Timestamptz{InfinityModifier: value, Status: Present}
 	default:
 		if originalSrc, ok := underlyingTimeType(src); ok {
 			return dst.Set(originalSrc)

--- a/timestamptz_test.go
+++ b/timestamptz_test.go
@@ -91,6 +91,8 @@ func TestTimestamptzSet(t *testing.T) {
 		{source: time.Date(2000, 1, 1, 0, 0, 1, 0, time.Local), result: pgtype.Timestamptz{Time: time.Date(2000, 1, 1, 0, 0, 1, 0, time.Local), Status: pgtype.Present}},
 		{source: time.Date(2200, 1, 1, 0, 0, 0, 0, time.Local), result: pgtype.Timestamptz{Time: time.Date(2200, 1, 1, 0, 0, 0, 0, time.Local), Status: pgtype.Present}},
 		{source: _time(time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local)), result: pgtype.Timestamptz{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local), Status: pgtype.Present}},
+		{source: pgtype.Infinity, result: pgtype.Timestamptz{InfinityModifier: pgtype.Infinity, Status: pgtype.Present}},
+		{source: pgtype.NegativeInfinity, result: pgtype.Timestamptz{InfinityModifier: pgtype.NegativeInfinity, Status: pgtype.Present}},
 	}
 
 	for i, tt := range successfulTests {


### PR DESCRIPTION
I noticed that I got
> ERROR: COPY from stdin failed: cannot convert infinity to Timestamp (SQLSTATE 57014)

in pgx when copying from rows that contained infinite timestamps.

This PR makes timestamps settable from `InfinityModifier` to mirror the `Get()` behavior, and make straight copy operations work for infinite timestamp values.

