### PR TITLE
Fixes #68 - Adds checks for zero length arrays/slices.

### DIFF
--- a/aclitem_array.go
+++ b/aclitem_array.go
@@ -190,6 +190,10 @@ func (dst ACLItemArray) Get() interface{} {
 func (src *ACLItemArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/aclitem_array_test.go
+++ b/aclitem_array_test.go
@@ -190,6 +190,11 @@ func TestACLItemArrayAssignTo(t *testing.T) {
 			expected: (([]string)(nil)),
 		},
 		{
+			src:      pgtype.ACLItemArray{Status: pgtype.Present},
+			dst:      &stringSlice,
+			expected: (([]string)(nil)),
+		},
+		{
 			src: pgtype.ACLItemArray{
 				Elements: []pgtype.ACLItem{
 					{String: "=r/postgres", Status: pgtype.Present},

--- a/bool_array.go
+++ b/bool_array.go
@@ -192,6 +192,10 @@ func (dst BoolArray) Get() interface{} {
 func (src *BoolArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/bool_array_test.go
+++ b/bool_array_test.go
@@ -169,6 +169,11 @@ func TestBoolArrayAssignTo(t *testing.T) {
 			expected: (([]bool)(nil)),
 		},
 		{
+			src:      pgtype.BoolArray{Status: pgtype.Present},
+			dst:      &boolSlice,
+			expected: (([]bool)(nil)),
+		},
+		{
 			src: pgtype.BoolArray{
 				Elements:   []pgtype.Bool{{Bool: true, Status: pgtype.Present}, {Bool: false, Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/bpchar_array.go
+++ b/bpchar_array.go
@@ -192,6 +192,10 @@ func (dst BPCharArray) Get() interface{} {
 func (src *BPCharArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/bytea_array.go
+++ b/bytea_array.go
@@ -173,6 +173,10 @@ func (dst ByteaArray) Get() interface{} {
 func (src *ByteaArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/bytea_array_test.go
+++ b/bytea_array_test.go
@@ -158,6 +158,11 @@ func TestByteaArrayAssignTo(t *testing.T) {
 			expected: (([][]byte)(nil)),
 		},
 		{
+			src:      pgtype.ByteaArray{Status: pgtype.Present},
+			dst:      &byteByteSlice,
+			expected: (([][]byte)(nil)),
+		},
+		{
 			src: pgtype.ByteaArray{
 				Elements:   []pgtype.Bytea{{Bytes: []byte{1}, Status: pgtype.Present}, {Bytes: []byte{2}, Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/cidr_array.go
+++ b/cidr_array.go
@@ -212,6 +212,10 @@ func (dst CIDRArray) Get() interface{} {
 func (src *CIDRArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/cidr_array_test.go
+++ b/cidr_array_test.go
@@ -218,7 +218,17 @@ func TestCIDRArrayAssignTo(t *testing.T) {
 			expected: (([]*net.IPNet)(nil)),
 		},
 		{
+			src:      pgtype.CIDRArray{Status: pgtype.Present},
+			dst:      &ipnetSlice,
+			expected: (([]*net.IPNet)(nil)),
+		},
+		{
 			src:      pgtype.CIDRArray{Status: pgtype.Null},
+			dst:      &ipSlice,
+			expected: (([]net.IP)(nil)),
+		},
+		{
+			src:      pgtype.CIDRArray{Status: pgtype.Present},
 			dst:      &ipSlice,
 			expected: (([]net.IP)(nil)),
 		},

--- a/date_array.go
+++ b/date_array.go
@@ -193,6 +193,10 @@ func (dst DateArray) Get() interface{} {
 func (src *DateArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/date_array_test.go
+++ b/date_array_test.go
@@ -183,6 +183,11 @@ func TestDateArrayAssignTo(t *testing.T) {
 			expected: (([]time.Time)(nil)),
 		},
 		{
+			src:      pgtype.DateArray{Status: pgtype.Present},
+			dst:      &timeSlice,
+			expected: (([]time.Time)(nil)),
+		},
+		{
 			src: pgtype.DateArray{
 				Elements: []pgtype.Date{
 					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},

--- a/enum_array.go
+++ b/enum_array.go
@@ -190,6 +190,10 @@ func (dst EnumArray) Get() interface{} {
 func (src *EnumArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/enum_array_test.go
+++ b/enum_array_test.go
@@ -168,6 +168,11 @@ func TestEnumArrayArrayAssignTo(t *testing.T) {
 			expected: (([]string)(nil)),
 		},
 		{
+			src:      pgtype.EnumArray{Status: pgtype.Present},
+			dst:      &stringSlice,
+			expected: (([]string)(nil)),
+		},
+		{
 			src: pgtype.EnumArray{
 				Elements:   []pgtype.GenericText{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/float4_array.go
+++ b/float4_array.go
@@ -192,6 +192,10 @@ func (dst Float4Array) Get() interface{} {
 func (src *Float4Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/float4_array_test.go
+++ b/float4_array_test.go
@@ -168,6 +168,11 @@ func TestFloat4ArrayAssignTo(t *testing.T) {
 			expected: (([]float32)(nil)),
 		},
 		{
+			src:      pgtype.Float4Array{Status: pgtype.Present},
+			dst:      &float32Slice,
+			expected: (([]float32)(nil)),
+		},
+		{
 			src: pgtype.Float4Array{
 				Elements:   []pgtype.Float4{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/float8_array.go
+++ b/float8_array.go
@@ -192,6 +192,10 @@ func (dst Float8Array) Get() interface{} {
 func (src *Float8Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/float8_array_test.go
+++ b/float8_array_test.go
@@ -144,6 +144,11 @@ func TestFloat8ArrayAssignTo(t *testing.T) {
 			expected: (([]float64)(nil)),
 		},
 		{
+			src:      pgtype.Float8Array{Status: pgtype.Present},
+			dst:      &float64Slice,
+			expected: (([]float64)(nil)),
+		},
+		{
 			src: pgtype.Float8Array{
 				Elements:   []pgtype.Float8{{Float: 1, Status: pgtype.Present}, {Float: 2, Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/hstore_array.go
+++ b/hstore_array.go
@@ -173,6 +173,10 @@ func (dst HstoreArray) Get() interface{} {
 func (src *HstoreArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/hstore_array_test.go
+++ b/hstore_array_test.go
@@ -303,6 +303,9 @@ func TestHstoreArrayAssignTo(t *testing.T) {
 			src: pgtype.HstoreArray{Status: pgtype.Null}, dst: &hstoreSlice, expected: (([]map[string]string)(nil)),
 		},
 		{
+			src: pgtype.HstoreArray{Status: pgtype.Present}, dst: &hstoreSlice, expected: (([]map[string]string)(nil)),
+		},
+		{
 			src: pgtype.HstoreArray{
 				Elements: []pgtype.Hstore{
 					{

--- a/inet_array.go
+++ b/inet_array.go
@@ -212,6 +212,10 @@ func (dst InetArray) Get() interface{} {
 func (src *InetArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/inet_array_test.go
+++ b/inet_array_test.go
@@ -218,7 +218,17 @@ func TestInetArrayAssignTo(t *testing.T) {
 			expected: (([]*net.IPNet)(nil)),
 		},
 		{
+			src:      pgtype.InetArray{Status: pgtype.Present},
+			dst:      &ipnetSlice,
+			expected: (([]*net.IPNet)(nil)),
+		},
+		{
 			src:      pgtype.InetArray{Status: pgtype.Null},
+			dst:      &ipSlice,
+			expected: (([]net.IP)(nil)),
+		},
+		{
+			src:      pgtype.InetArray{Status: pgtype.Present},
 			dst:      &ipSlice,
 			expected: (([]net.IP)(nil)),
 		},

--- a/int2_array.go
+++ b/int2_array.go
@@ -458,6 +458,10 @@ func (dst Int2Array) Get() interface{} {
 func (src *Int2Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/int2_array_test.go
+++ b/int2_array_test.go
@@ -220,6 +220,11 @@ func TestInt2ArrayAssignTo(t *testing.T) {
 			expected: (([]int16)(nil)),
 		},
 		{
+			src:      pgtype.Int2Array{Status: pgtype.Present},
+			dst:      &int16Slice,
+			expected: (([]int16)(nil)),
+		},
+		{
 			src: pgtype.Int2Array{
 				Elements:   []pgtype.Int2{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/int4_array.go
+++ b/int4_array.go
@@ -458,6 +458,10 @@ func (dst Int4Array) Get() interface{} {
 func (src *Int4Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/int4_array_test.go
+++ b/int4_array_test.go
@@ -234,6 +234,11 @@ func TestInt4ArrayAssignTo(t *testing.T) {
 			expected: (([]int32)(nil)),
 		},
 		{
+			src:      pgtype.Int4Array{Status: pgtype.Present},
+			dst:      &int32Slice,
+			expected: (([]int32)(nil)),
+		},
+		{
 			src: pgtype.Int4Array{
 				Elements:   []pgtype.Int4{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/int8_array.go
+++ b/int8_array.go
@@ -458,6 +458,10 @@ func (dst Int8Array) Get() interface{} {
 func (src *Int8Array) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/int8_array_test.go
+++ b/int8_array_test.go
@@ -227,6 +227,11 @@ func TestInt8ArrayAssignTo(t *testing.T) {
 			expected: (([]int64)(nil)),
 		},
 		{
+			src:      pgtype.Int8Array{Status: pgtype.Present},
+			dst:      &int64Slice,
+			expected: (([]int64)(nil)),
+		},
+		{
 			src: pgtype.Int8Array{
 				Elements:   []pgtype.Int8{{Int: 1, Status: pgtype.Present}, {Int: 2, Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/jsonb_array.go
+++ b/jsonb_array.go
@@ -192,6 +192,10 @@ func (dst JSONBArray) Get() interface{} {
 func (src *JSONBArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/macaddr_array.go
+++ b/macaddr_array.go
@@ -193,6 +193,10 @@ func (dst MacaddrArray) Get() interface{} {
 func (src *MacaddrArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/macaddr_array_test.go
+++ b/macaddr_array_test.go
@@ -167,6 +167,11 @@ func TestMacaddrArrayAssignTo(t *testing.T) {
 			expected: (([]net.HardwareAddr)(nil)),
 		},
 		{
+			src:      pgtype.MacaddrArray{Status: pgtype.Present},
+			dst:      &macaddrSlice,
+			expected: (([]net.HardwareAddr)(nil)),
+		},
+		{
 			src: pgtype.MacaddrArray{
 				Elements: []pgtype.Macaddr{
 					{Addr: mustParseMacaddr(t, "01:23:45:67:89:ab"), Status: pgtype.Present},

--- a/numeric_array.go
+++ b/numeric_array.go
@@ -306,6 +306,10 @@ func (dst NumericArray) Get() interface{} {
 func (src *NumericArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/numeric_array_test.go
+++ b/numeric_array_test.go
@@ -191,6 +191,11 @@ func TestNumericArrayAssignTo(t *testing.T) {
 			expected: (([]float32)(nil)),
 		},
 		{
+			src:      pgtype.NumericArray{Status: pgtype.Present},
+			dst:      &float32Slice,
+			expected: (([]float32)(nil)),
+		},
+		{
 			src: pgtype.NumericArray{
 				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}, {Int: big.NewInt(2), Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/text_array.go
+++ b/text_array.go
@@ -192,6 +192,10 @@ func (dst TextArray) Get() interface{} {
 func (src *TextArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/text_array_test.go
+++ b/text_array_test.go
@@ -169,6 +169,11 @@ func TestTextArrayAssignTo(t *testing.T) {
 			expected: (([]string)(nil)),
 		},
 		{
+			src:      pgtype.TextArray{Status: pgtype.Present},
+			dst:      &stringSlice,
+			expected: (([]string)(nil)),
+		},
+		{
 			src: pgtype.TextArray{
 				Elements:   []pgtype.Text{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},

--- a/timestamp_array.go
+++ b/timestamp_array.go
@@ -193,6 +193,10 @@ func (dst TimestampArray) Get() interface{} {
 func (src *TimestampArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/timestamp_array_test.go
+++ b/timestamp_array_test.go
@@ -163,6 +163,11 @@ func TestTimestampArrayAssignTo(t *testing.T) {
 			expected: (([]time.Time)(nil)),
 		},
 		{
+			src:      pgtype.TimestampArray{Status: pgtype.Present},
+			dst:      &timeSlice,
+			expected: (([]time.Time)(nil)),
+		},
+		{
 			src: pgtype.TimestampArray{
 				Elements: []pgtype.Timestamp{
 					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},

--- a/timestamptz_array.go
+++ b/timestamptz_array.go
@@ -193,6 +193,10 @@ func (dst TimestamptzArray) Get() interface{} {
 func (src *TimestamptzArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/timestamptz_array_test.go
+++ b/timestamptz_array_test.go
@@ -199,6 +199,11 @@ func TestTimestamptzArrayAssignTo(t *testing.T) {
 			expected: (([]time.Time)(nil)),
 		},
 		{
+			src:      pgtype.TimestamptzArray{Status: pgtype.Present},
+			dst:      &timeSlice,
+			expected: (([]time.Time)(nil)),
+		},
+		{
 			src: pgtype.TimestamptzArray{
 				Elements: []pgtype.Timestamptz{
 					{Time: time.Date(2015, 2, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present},

--- a/tstzrange_array.go
+++ b/tstzrange_array.go
@@ -154,6 +154,10 @@ func (dst TstzrangeArray) Get() interface{} {
 func (src *TstzrangeArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/typed_array.go.erb
+++ b/typed_array.go.erb
@@ -174,6 +174,10 @@ func (dst <%= pgtype_array_type %>) Get() interface{} {
 func (src *<%= pgtype_array_type %>) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1{
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/uuid_array.go
+++ b/uuid_array.go
@@ -230,6 +230,10 @@ func (dst UUIDArray) Get() interface{} {
 func (src *UUIDArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/uuid_array_test.go
+++ b/uuid_array_test.go
@@ -214,6 +214,7 @@ func TestUUIDArrayAssignTo(t *testing.T) {
 	var byteArraySlice [][16]byte
 	var byteSliceSlice [][]byte
 	var stringSlice []string
+	var byteSlice []byte
 	var byteArraySliceDim2 [][][16]byte
 	var stringSliceDim4 [][][][]string
 	var byteArrayDim2 [2][1][16]byte
@@ -251,6 +252,16 @@ func TestUUIDArrayAssignTo(t *testing.T) {
 			src:      pgtype.UUIDArray{Status: pgtype.Null},
 			dst:      &byteSliceSlice,
 			expected: ([][]byte)(nil),
+		},
+		{
+			src:      pgtype.UUIDArray{Status: pgtype.Present},
+			dst:      &byteSlice,
+			expected: ([]byte)(nil),
+		},
+		{
+			src:      pgtype.UUIDArray{Status: pgtype.Present},
+			dst:      &stringSlice,
+			expected: (([]string)(nil)),
 		},
 		{
 			src: pgtype.UUIDArray{

--- a/varchar_array.go
+++ b/varchar_array.go
@@ -192,6 +192,10 @@ func (dst VarcharArray) Get() interface{} {
 func (src *VarcharArray) AssignTo(dst interface{}) error {
 	switch src.Status {
 	case Present:
+		if len(src.Elements) == 0 || len(src.Dimensions) == 0 {
+			// No values to assign
+			return nil
+		}
 		if len(src.Dimensions) <= 1 {
 			// Attempt to match to select common types:
 			switch v := dst.(type) {

--- a/varchar_array_test.go
+++ b/varchar_array_test.go
@@ -169,6 +169,11 @@ func TestVarcharArrayAssignTo(t *testing.T) {
 			expected: (([]string)(nil)),
 		},
 		{
+			src:      pgtype.VarcharArray{Status: pgtype.Present},
+			dst:      &stringSlice,
+			expected: (([]string)(nil)),
+		},
+		{
 			src: pgtype.VarcharArray{
 				Elements:   []pgtype.Varchar{{String: "foo", Status: pgtype.Present}, {String: "bar", Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 2}, {LowerBound: 1, Length: 1}},


### PR DESCRIPTION
Fixes #68

### The problem:
The following code (or any other array/slice type!):
```golang
var t []uuid.UUID
tx.QueryRow(ctx, `select '{}'::uuid[]`).Scan(&t)
```

Causes the `src` struct in the `AssignTo` function to have `Elements` and `Dimensions` set as `nil`, but `Status` as `Present`.

### The proposed solution:
- Adds checks for nil or zero length elements or dimensions in the `AssignTo` function where the `src` is marked as `Present`, but the `Elements` or `Dimensions` are `nil`.
- Returns immediately for nil and zero length arrays and slices.
- Adds the above issue as test cases for all array types.
- Only 4 lines of new code in `typed_array.go.erb` + test cases.
