### PR TITLE
Adds support for scientific notation.

### DIFF
--- a/numeric.go
+++ b/numeric.go
@@ -421,7 +421,18 @@ func (dst *Numeric) DecodeText(ci *ConnInfo, src []byte) error {
 }
 
 func parseNumericString(str string) (n *big.Int, exp int32, err error) {
-	parts := strings.SplitN(str, ".", 2)
+	parts := strings.SplitN(str, "e", 2)
+	if len(parts) > 1 {
+		sciExp, err := strconv.ParseInt(parts[1], 10, 32)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		n, exp, err = parseNumericString(parts[0])
+		return n, exp + int32(sciExp), err
+	}
+
+	parts = strings.SplitN(str, ".", 2)
 	digits := strings.Join(parts, "")
 
 	if len(parts) > 1 {

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -205,6 +205,7 @@ func TestNumericSet(t *testing.T) {
 		{source: uint32(1), result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},
 		{source: uint64(1), result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},
 		{source: "1", result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},
+		{source: "600000000000000e-12", result: &pgtype.Numeric{Int: big.NewInt(6), Exp: 2, Status: pgtype.Present}},
 		{source: _int8(1), result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},
 		{source: float64(1000), result: &pgtype.Numeric{Int: big.NewInt(1), Exp: 3, Status: pgtype.Present}},
 		{source: float64(1234), result: &pgtype.Numeric{Int: big.NewInt(1234), Exp: 0, Status: pgtype.Present}},


### PR DESCRIPTION
Connecting with pgx to a postgresql 10.7, a `numeric(27, 12)` column
containing 600 was sending the string `600000000000000e-12`.
This supports such a string in `parseNumericString` and adds a test.