### PR TITLE
Normalize UTC timestamps to comply with stdlib

### DIFF
--- a/timestamptz.go
+++ b/timestamptz.go
@@ -124,7 +124,7 @@ func (dst *Timestamptz) DecodeText(ci *ConnInfo, src []byte) error {
 			return err
 		}
 
-		*dst = Timestamptz{Time: tim, Status: Present}
+		*dst = Timestamptz{Time: normalizePotentialUTC(tim), Status: Present}
 	}
 
 	return nil
@@ -229,6 +229,9 @@ func (src Timestamptz) Value() (driver.Value, error) {
 		if src.InfinityModifier != None {
 			return src.InfinityModifier.String(), nil
 		}
+		if src.Time.Location().String() == time.UTC.String() {
+			return src.Time.UTC(), nil
+		}
 		return src.Time, nil
 	case Null:
 		return nil, nil
@@ -287,8 +290,23 @@ func (dst *Timestamptz) UnmarshalJSON(b []byte) error {
 			return err
 		}
 
-		*dst = Timestamptz{Time: tim, Status: Present}
+		*dst = Timestamptz{Time: normalizePotentialUTC(tim), Status: Present}
 	}
 
 	return nil
+}
+
+// Normalize timestamps in UTC location to behave similarly to how the Golang
+// standard library does it: UTC timestamps lack a .loc value.
+//
+// Reason for this: when comparing two timestamps with reflect.DeepEqual (generally
+// speaking not a good idea, but several testing libraries (for example testify)
+// does this), their location data needs to be equal for them to be considered
+// equal.
+func normalizePotentialUTC(timestamp time.Time) time.Time {
+	if timestamp.Location().String() != time.UTC.String() {
+		return timestamp
+	}
+
+	return timestamp.UTC()
 }

--- a/timestamptz_test.go
+++ b/timestamptz_test.go
@@ -49,8 +49,7 @@ func TestTimestamptzNanosecondsTruncated(t *testing.T) {
 				t.Errorf("%d. EncodeText failed - %v", i, err)
 			}
 
-			tstz.DecodeText(nil, buf)
-			if err != nil {
+			if err := tstz.DecodeText(nil, buf); err != nil {
 				t.Errorf("%d. DecodeText failed - %v", i, err)
 			}
 
@@ -66,8 +65,7 @@ func TestTimestamptzNanosecondsTruncated(t *testing.T) {
 				t.Errorf("%d. EncodeBinary failed - %v", i, err)
 			}
 
-			tstz.DecodeBinary(nil, buf)
-			if err != nil {
+			if err := tstz.DecodeBinary(nil, buf); err != nil {
 				t.Errorf("%d. DecodeBinary failed - %v", i, err)
 			}
 


### PR DESCRIPTION
This is a solution for the following issue I experienced when migrating from lib/pq to pgx: https://github.com/jackc/pgx/issues/863