### PR TITLE
Update go.mod to go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackc/pgtype
 
-go 1.12
+go 1.13
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible


### PR DESCRIPTION
Addresses #95 so that users see that go 1.13 is required.