### PR TITLE
Support pointers of Numeric

### DIFF
--- a/numeric.go
+++ b/numeric.go
@@ -345,6 +345,8 @@ func (src *Numeric) AssignTo(dst interface{}) error {
 				return fmt.Errorf("%d is greater than maximum value for %T", normalizedInt, *v)
 			}
 			*v = normalizedInt.Uint64()
+		case **Numeric:
+			*v = src
 		default:
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -248,6 +248,7 @@ func TestNumericAssignTo(t *testing.T) {
 	var f64 float64
 	var pf32 *float32
 	var pf64 *float64
+	var pNum *pgtype.Numeric
 
 	simpleTests := []struct {
 		src      *pgtype.Numeric
@@ -312,6 +313,7 @@ func TestNumericAssignTo(t *testing.T) {
 	}{
 		{src: &pgtype.Numeric{Int: big.NewInt(42), Status: pgtype.Present}, dst: &pf32, expected: float32(42)},
 		{src: &pgtype.Numeric{Int: big.NewInt(42), Status: pgtype.Present}, dst: &pf64, expected: float64(42)},
+		{src: &pgtype.Numeric{Int: big.NewInt(42), Status: pgtype.Present}, dst: &pNum, expected: pgtype.Numeric{Int: big.NewInt(42), Status: pgtype.Present}},
 	}
 
 	for i, tt := range pointerAllocTests {
@@ -320,7 +322,7 @@ func TestNumericAssignTo(t *testing.T) {
 			t.Errorf("%d: %v", i, err)
 		}
 
-		if dst := reflect.ValueOf(tt.dst).Elem().Elem().Interface(); dst != tt.expected {
+		if dst := reflect.ValueOf(tt.dst).Elem().Elem().Interface(); !reflect.DeepEqual(dst, tt.expected) {
 			t.Errorf("%d: expected %v to assign %v, but result was %v", i, tt.src, tt.expected, dst)
 		}
 	}


### PR DESCRIPTION
It is now possible to scan a Numeric pointer for values.
This is because all pointer types that can be converted from the already implemented Numeric types will lose some information.

relates to jackc/pgx#1000