### PR TITLE
Decode JSONBOID as binary bytes, like TextOID and JSONOID

### DIFF
--- a/pgtype.go
+++ b/pgtype.go
@@ -783,7 +783,7 @@ func (ci *ConnInfo) PlanScan(oid uint32, formatCode int16, dst interface{}) Scan
 			}
 		case *[]byte:
 			switch oid {
-			case ByteaOID, TextOID, VarcharOID, JSONOID:
+			case ByteaOID, TextOID, VarcharOID, JSONOID, JSONBOID:
 				return scanPlanBinaryBytes{}
 			}
 		case BinaryDecoder:


### PR DESCRIPTION
This results in a >10x improvement in throughput when working with the JSONB data type.