### PR TITLE
Fix int64 overflow error

### DIFF
--- a/timestamptz.go
+++ b/timestamptz.go
@@ -148,8 +148,10 @@ func (dst *Timestamptz) DecodeBinary(ci *ConnInfo, src []byte) error {
 	case negativeInfinityMicrosecondOffset:
 		*dst = Timestamptz{Status: Present, InfinityModifier: -Infinity}
 	default:
-		microsecSinceUnixEpoch := microsecFromUnixEpochToY2K + microsecSinceY2K
-		tim := time.Unix(microsecSinceUnixEpoch/1000000, (microsecSinceUnixEpoch%1000000)*1000)
+		tim := time.Unix(
+			microsecFromUnixEpochToY2K/1000000+microsecSinceY2K/1000000,
+			(microsecFromUnixEpochToY2K%1000000*1000)+(microsecSinceY2K%1000000*1000),
+		)
 		*dst = Timestamptz{Time: tim, Status: Present}
 	}
 


### PR DESCRIPTION
### Issue
In timestamptz.go `DecodeBinary` method
When value from database is set to max timestamptz specified in [postgresql docs](https://www.postgresql.org/docs/current/datatype-datetime.html) i.e. 294276 AD, `microsecSinceY2K` takes on value `9223371331199999999` causing the following line to overflow the Int64 limit:
`microsecSinceUnixEpoch := microsecFromUnixEpochToY2K + microsecSinceY2K`

This causes the wrong date to be decoded
DB Date: `294276-12-31 23:59:59.999999+00`
Result: `-290278-12-14 15:58:10.448383 +0000 UTC`

To reproduce:
```
var timetz pgtype.Timestamptz
conn.QueryRow(context.Background(), `SELECT '294276-12-31 23:59:59.999999+00'::timestamptz`).Scan(&timetz)
fmt.Print(timetz)
```

### Fix
See code
New result decodes correctly to `294276-12-31 23:59:59.999999 +0000 UTC`


