### PR TITLE
correctly Scan type aliases for floating point types

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -337,6 +337,10 @@ func float64AssignTo(srcVal float64, srcStatus Status, dst interface{}) error {
 			if v := reflect.ValueOf(dst); v.Kind() == reflect.Ptr {
 				el := v.Elem()
 				switch el.Kind() {
+				// if dst is a type alias of a float32 or 64, set dst val
+				case reflect.Float32, reflect.Float64:
+					el.SetFloat(srcVal)
+					return nil
 				// if dst is a pointer to pointer, strip the pointer and try again
 				case reflect.Ptr:
 					if el.IsNil() {

--- a/float4_test.go
+++ b/float4_test.go
@@ -56,6 +56,9 @@ func TestFloat4Set(t *testing.T) {
 }
 
 func TestFloat4AssignTo(t *testing.T) {
+	type aliasf32 float32
+	type aliasf64 float64
+
 	var i8 int8
 	var i16 int16
 	var i32 int32
@@ -73,6 +76,8 @@ func TestFloat4AssignTo(t *testing.T) {
 	var f64 float64
 	var pf32 *float32
 	var pf64 *float64
+	var a32 aliasf32
+	var a64 aliasf64
 
 	simpleTests := []struct {
 		src      pgtype.Float4
@@ -91,6 +96,8 @@ func TestFloat4AssignTo(t *testing.T) {
 		{src: pgtype.Float4{Float: 42, Status: pgtype.Present}, dst: &ui64, expected: uint64(42)},
 		{src: pgtype.Float4{Float: 42, Status: pgtype.Present}, dst: &ui, expected: uint(42)},
 		{src: pgtype.Float4{Float: 42, Status: pgtype.Present}, dst: &_i8, expected: _int8(42)},
+		{src: pgtype.Float4{Float: 42, Status: pgtype.Present}, dst: &a32, expected: aliasf32(42)},
+		{src: pgtype.Float4{Float: 42, Status: pgtype.Present}, dst: &a64, expected: aliasf64(42)},
 		{src: pgtype.Float4{Float: 0, Status: pgtype.Null}, dst: &pi8, expected: ((*int8)(nil))},
 		{src: pgtype.Float4{Float: 0, Status: pgtype.Null}, dst: &_pi8, expected: ((*_int8)(nil))},
 	}

--- a/float8_test.go
+++ b/float8_test.go
@@ -56,6 +56,9 @@ func TestFloat8Set(t *testing.T) {
 }
 
 func TestFloat8AssignTo(t *testing.T) {
+	type aliasf32 float32
+	type aliasf64 float64
+
 	var i8 int8
 	var i16 int16
 	var i32 int32
@@ -73,6 +76,8 @@ func TestFloat8AssignTo(t *testing.T) {
 	var f64 float64
 	var pf32 *float32
 	var pf64 *float64
+	var a32 aliasf32
+	var a64 aliasf64
 
 	simpleTests := []struct {
 		src      pgtype.Float8
@@ -91,6 +96,9 @@ func TestFloat8AssignTo(t *testing.T) {
 		{src: pgtype.Float8{Float: 42, Status: pgtype.Present}, dst: &ui64, expected: uint64(42)},
 		{src: pgtype.Float8{Float: 42, Status: pgtype.Present}, dst: &ui, expected: uint(42)},
 		{src: pgtype.Float8{Float: 42, Status: pgtype.Present}, dst: &_i8, expected: _int8(42)},
+		{src: pgtype.Float8{Float: 42, Status: pgtype.Present}, dst: &a32, expected: aliasf32(42)},
+		{src: pgtype.Float8{Float: 42, Status: pgtype.Present}, dst: &a64, expected: aliasf64(42)},
+
 		{src: pgtype.Float8{Float: 0, Status: pgtype.Null}, dst: &pi8, expected: ((*int8)(nil))},
 		{src: pgtype.Float8{Float: 0, Status: pgtype.Null}, dst: &_pi8, expected: ((*_int8)(nil))},
 	}


### PR DESCRIPTION
Saw [this](https://github.com/jackc/pgx/issues/1151) bug ticket and used it as an opportunity to learn a bit more about `pgx`.


Let me know if there is anything missing, it seems like a pretty cut and dry issue to solve. I will admit my knowledge of the reflection library is relatively limited but I think this approach makes sense.