### PR TITLE
Fix/jsonbarray set json rawmessage

### DIFF
--- a/jsonb_array_test.go
+++ b/jsonb_array_test.go
@@ -1,6 +1,8 @@
 package pgtype_test
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/jackc/pgtype"
@@ -33,4 +35,54 @@ func TestJSONBArrayTranscode(t *testing.T) {
 			Status:     pgtype.Present,
 		},
 	})
+}
+
+func TestJSONBArraySet(t *testing.T) {
+	successfulTests := []struct {
+		source interface{}
+		result pgtype.JSONBArray
+	}{
+		{source: []string{"{}"}, result: pgtype.JSONBArray{
+			Elements:   []pgtype.JSONB{pgtype.JSONB{Bytes: []byte("{}"), Status: pgtype.Present}},
+			Dimensions: []pgtype.ArrayDimension{pgtype.ArrayDimension{Length: 1, LowerBound: 1}},
+			Status:     pgtype.Present,
+		}},
+		{source: [][]byte{[]byte("{}")}, result: pgtype.JSONBArray{
+			Elements:   []pgtype.JSONB{pgtype.JSONB{Bytes: []byte("{}"), Status: pgtype.Present}},
+			Dimensions: []pgtype.ArrayDimension{pgtype.ArrayDimension{Length: 1, LowerBound: 1}},
+			Status:     pgtype.Present,
+		}},
+		{source: [][]byte{[]byte(`{"foo":1}`), []byte(`{"bar":2}`)}, result: pgtype.JSONBArray{
+			Elements:   []pgtype.JSONB{pgtype.JSONB{Bytes: []byte(`{"foo":1}`), Status: pgtype.Present}, pgtype.JSONB{Bytes: []byte(`{"bar":2}`), Status: pgtype.Present}},
+			Dimensions: []pgtype.ArrayDimension{pgtype.ArrayDimension{Length: 2, LowerBound: 1}},
+			Status:     pgtype.Present,
+		}},
+		{source: []json.RawMessage{json.RawMessage(`{"foo":1}`), json.RawMessage(`{"bar":2}`)}, result: pgtype.JSONBArray{
+			Elements:   []pgtype.JSONB{pgtype.JSONB{Bytes: []byte(`{"foo":1}`), Status: pgtype.Present}, pgtype.JSONB{Bytes: []byte(`{"bar":2}`), Status: pgtype.Present}},
+			Dimensions: []pgtype.ArrayDimension{pgtype.ArrayDimension{Length: 2, LowerBound: 1}},
+			Status:     pgtype.Present,
+		}},
+		{source: []json.RawMessage{json.RawMessage(`{"foo":12}`), json.RawMessage(`{"bar":2}`)}, result: pgtype.JSONBArray{
+			Elements:   []pgtype.JSONB{pgtype.JSONB{Bytes: []byte(`{"foo":12}`), Status: pgtype.Present}, pgtype.JSONB{Bytes: []byte(`{"bar":2}`), Status: pgtype.Present}},
+			Dimensions: []pgtype.ArrayDimension{pgtype.ArrayDimension{Length: 2, LowerBound: 1}},
+			Status:     pgtype.Present,
+		}},
+		{source: []json.RawMessage{json.RawMessage(`{"foo":1}`), json.RawMessage(`{"bar":{"x":2}}`)}, result: pgtype.JSONBArray{
+			Elements:   []pgtype.JSONB{pgtype.JSONB{Bytes: []byte(`{"foo":1}`), Status: pgtype.Present}, pgtype.JSONB{Bytes: []byte(`{"bar":{"x":2}}`), Status: pgtype.Present}},
+			Dimensions: []pgtype.ArrayDimension{pgtype.ArrayDimension{Length: 2, LowerBound: 1}},
+			Status:     pgtype.Present,
+		}},
+	}
+
+	for i, tt := range successfulTests {
+		var d pgtype.JSONBArray
+		err := d.Set(tt.source)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if !reflect.DeepEqual(d, tt.result) {
+			t.Errorf("%d: expected %+v to convert to %+v, but it was %+v", i, tt.source, tt.result, d)
+		}
+	}
 }

--- a/typed_array_gen.sh
+++ b/typed_array_gen.sh
@@ -20,7 +20,7 @@ erb pgtype_array_type=ACLItemArray pgtype_element_type=ACLItem go_array_types=[]
 erb pgtype_array_type=HstoreArray pgtype_element_type=Hstore go_array_types=[]map[string]string element_type_name=hstore text_null=NULL binary_format=true typed_array.go.erb > hstore_array.go
 erb pgtype_array_type=NumericArray pgtype_element_type=Numeric go_array_types=[]float32,[]*float32,[]float64,[]*float64,[]int64,[]*int64,[]uint64,[]*uint64 element_type_name=numeric text_null=NULL binary_format=true typed_array.go.erb > numeric_array.go
 erb pgtype_array_type=UUIDArray pgtype_element_type=UUID go_array_types=[][16]byte,[][]byte,[]string,[]*string element_type_name=uuid text_null=NULL binary_format=true typed_array.go.erb > uuid_array.go
-erb pgtype_array_type=JSONBArray pgtype_element_type=JSONB go_array_types=[]string,[][]byte element_type_name=jsonb text_null=NULL binary_format=true typed_array.go.erb > jsonb_array.go
+erb pgtype_array_type=JSONBArray pgtype_element_type=JSONB go_array_types=[]string,[][]byte,[]json.RawMessage element_type_name=jsonb text_null=NULL binary_format=true typed_array.go.erb > jsonb_array.go
 
 # While the binary format is theoretically possible it is only practical to use the text format.
 erb pgtype_array_type=EnumArray pgtype_element_type=GenericText go_array_types=[]string,[]*string text_null=NULL binary_format=false typed_array.go.erb > enum_array.go


### PR DESCRIPTION
Following jacks comment [here](https://github.com/jackc/pgtype/issues/149#issuecomment-1065764402), I added `json.RawMessage` to `type_array_gen.sh`.

This will fix the particular case of using `.Set` on sources of type `[]json.RawMessage`. I added tests to confirm this.

However, it does not fix the fundamental issue in the sense that any other type alias for `[]byte` can reproduce the errors. I suspect this is due to a bug in the `default` reflect based case of `.Set`.

Since `json.RawMessage` is a type in the standard library, and since the non-reflect cases are more efficient, I thought this little addition may still provide some value.