### PR TITLE
allow string values in timestamp[tz].Set()

### DIFF
--- a/date.go
+++ b/date.go
@@ -37,14 +37,14 @@ func (dst *Date) Set(src interface{}) error {
 	switch value := src.(type) {
 	case time.Time:
 		*dst = Date{Time: value, Status: Present}
-	case string:
-		return dst.DecodeText(nil, []byte(value))
 	case *time.Time:
 		if value == nil {
 			*dst = Date{Status: Null}
 		} else {
 			return dst.Set(*value)
 		}
+	case string:
+		return dst.DecodeText(nil, []byte(value))
 	case *string:
 		if value == nil {
 			*dst = Date{Status: Null}

--- a/timestamp.go
+++ b/timestamp.go
@@ -46,6 +46,14 @@ func (dst *Timestamp) Set(src interface{}) error {
 		} else {
 			return dst.Set(*value)
 		}
+	case string:
+		return dst.DecodeText(nil, []byte(value))
+	case *string:
+		if value == nil {
+			*dst = Timestamp{Status: Null}
+		} else {
+			return dst.Set(*value)
+		}
 	case InfinityModifier:
 		*dst = Timestamp{InfinityModifier: value, Status: Present}
 	default:

--- a/timestamp_test.go
+++ b/timestamp_test.go
@@ -123,6 +123,7 @@ func TestTimestampSet(t *testing.T) {
 		{source: _time(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)), result: pgtype.Timestamp{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
 		{source: pgtype.Infinity, result: pgtype.Timestamp{InfinityModifier: pgtype.Infinity, Status: pgtype.Present}},
 		{source: pgtype.NegativeInfinity, result: pgtype.Timestamp{InfinityModifier: pgtype.NegativeInfinity, Status: pgtype.Present}},
+		{source: "2001-04-05 06:07:08", result: pgtype.Timestamp{Time: time.Date(2001, 4, 5, 6, 7, 8, 0, time.UTC), Status: pgtype.Present}},
 	}
 
 	for i, tt := range successfulTests {

--- a/timestamptz.go
+++ b/timestamptz.go
@@ -48,6 +48,14 @@ func (dst *Timestamptz) Set(src interface{}) error {
 		} else {
 			return dst.Set(*value)
 		}
+	case string:
+		return dst.DecodeText(nil, []byte(value))
+	case *string:
+		if value == nil {
+			*dst = Timestamptz{Status: Null}
+		} else {
+			return dst.Set(*value)
+		}
 	case InfinityModifier:
 		*dst = Timestamptz{InfinityModifier: value, Status: Present}
 	default:

--- a/timestamptz_test.go
+++ b/timestamptz_test.go
@@ -120,6 +120,7 @@ func TestTimestamptzSet(t *testing.T) {
 		{source: _time(time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local)), result: pgtype.Timestamptz{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local), Status: pgtype.Present}},
 		{source: pgtype.Infinity, result: pgtype.Timestamptz{InfinityModifier: pgtype.Infinity, Status: pgtype.Present}},
 		{source: pgtype.NegativeInfinity, result: pgtype.Timestamptz{InfinityModifier: pgtype.NegativeInfinity, Status: pgtype.Present}},
+		{source: "2020-04-05 06:07:08Z", result: pgtype.Timestamptz{Time: time.Date(2020, 4, 5, 6, 7, 8, 0, time.UTC), Status: pgtype.Present}},
 	}
 
 	for i, tt := range successfulTests {


### PR DESCRIPTION
Other similar Set() functions accept a string as value and convert it (Int4(), for example), so timestamp(tz) could do the same.