### PR TITLE
Hstore: fix AssignTo

### DIFF
--- a/hstore.go
+++ b/hstore.go
@@ -90,7 +90,8 @@ func (src *Hstore) AssignTo(dst interface{}) error {
 				case Null:
 					(*v)[k] = nil
 				case Present:
-					(*v)[k] = &val.String
+					str := val.String
+					(*v)[k] = &str
 				default:
 					return fmt.Errorf("cannot decode %#v into %T", src, dst)
 				}

--- a/hstore_test.go
+++ b/hstore_test.go
@@ -181,13 +181,14 @@ func TestHstoreAssignTo(t *testing.T) {
 
 func TestHstoreAssignToNullable(t *testing.T) {
 	var m map[string]*string
+	strPtr := func(str string) *string { return &str }
 
 	simpleTests := []struct {
 		src      pgtype.Hstore
 		dst      *map[string]*string
 		expected map[string]*string
 	}{
-		{src: pgtype.Hstore{Map: map[string]pgtype.Text{"foo": {Status: pgtype.Null}}, Status: pgtype.Present}, dst: &m, expected: map[string]*string{"foo": nil}},
+		{src: pgtype.Hstore{Map: map[string]pgtype.Text{"foo": {Status: pgtype.Null}, "bar": {String: "1", Status: pgtype.Present}, "baz": {String: "2", Status: pgtype.Present}}, Status: pgtype.Present}, dst: &m, expected: map[string]*string{"foo": nil, "bar": strPtr("1"), "baz": strPtr("2")}},
 		{src: pgtype.Hstore{Status: pgtype.Null}, dst: &m, expected: ((map[string]*string)(nil))},
 	}
 


### PR DESCRIPTION
Hstore.AssignTo, when assigning to a map of string pointers, takes the address of the loop variable, thus setting all the entries to the same string pointer.

It wasn't caught by the unit test as the test only tried it on a map of a single (null) entry.