### PR TITLE
protect against panic from PlanScan when interface{}(nil) is passed

### DIFF
--- a/pgtype.go
+++ b/pgtype.go
@@ -799,7 +799,7 @@ func isScanner(dst interface{}) bool {
 	if _, ok := dst.(sql.Scanner); ok {
 		return true
 	}
-	if t := reflect.TypeOf(dst); t.Kind() == reflect.Ptr && t.Elem().Implements(scannerType) {
+	if t := reflect.TypeOf(dst); t != nil && t.Kind() == reflect.Ptr && t.Elem().Implements(scannerType) {
 		return true
 	}
 	return false

--- a/pgtype_test.go
+++ b/pgtype_test.go
@@ -351,3 +351,13 @@ func TestScanPlanBinaryInt32ScanScanner(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, ptr)
 }
+
+// Test for https://github.com/jackc/pgtype/issues/164
+func TestScanPlanInterface(t *testing.T) {
+	ci := pgtype.NewConnInfo()
+	src := []byte{0, 42}
+	var v interface{}
+	plan := ci.PlanScan(pgtype.Int2OID, pgtype.BinaryFormatCode, v)
+	err := plan.Scan(ci, pgtype.Int2OID, pgtype.BinaryFormatCode, src, v)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Fixes #164 