### PR TITLE
Support Inet with encoding.Text(Un)Marshaler, fmt.Stringer

### DIFF
--- a/inet.go
+++ b/inet.go
@@ -2,6 +2,7 @@ package pgtype
 
 import (
 	"database/sql/driver"
+	"encoding"
 	"fmt"
 	"net"
 	"strings"
@@ -88,6 +89,13 @@ func (dst *Inet) Set(src interface{}) error {
 			return dst.Set(*value)
 		}
 	default:
+		if tv, ok := src.(encoding.TextMarshaler); ok {
+			text, err := tv.MarshalText()
+			if err != nil {
+				return fmt.Errorf("cannot marshal %v: %w", value, err)
+			}
+			return dst.Set(string(text))
+		}
 		if sv, ok := src.(fmt.Stringer); ok {
 			return dst.Set(sv.String())
 		}

--- a/inet.go
+++ b/inet.go
@@ -158,6 +158,12 @@ func (src *Inet) AssignTo(dst interface{}) error {
 			copy(*v, src.IPNet.IP)
 			return nil
 		default:
+			if tv, ok := dst.(encoding.TextUnmarshaler); ok {
+				if err := tv.UnmarshalText([]byte(src.IPNet.String())); err != nil {
+					return fmt.Errorf("cannot unmarshal %v to %T: %w", src, dst, err)
+				}
+				return nil
+			}
 			if nextDst, retry := GetAssignToDstType(dst); retry {
 				return src.AssignTo(nextDst)
 			}

--- a/inet.go
+++ b/inet.go
@@ -88,6 +88,9 @@ func (dst *Inet) Set(src interface{}) error {
 			return dst.Set(*value)
 		}
 	default:
+		if sv, ok := src.(fmt.Stringer); ok {
+			return dst.Set(sv.String())
+		}
 		if originalSrc, ok := underlyingPtrType(src); ok {
 			return dst.Set(originalSrc)
 		}

--- a/inet_test.go
+++ b/inet_test.go
@@ -46,6 +46,14 @@ func TestCidrTranscode(t *testing.T) {
 	})
 }
 
+type textMarshaler struct {
+	Text string
+}
+
+func (t textMarshaler) MarshalText() (text []byte, err error) {
+	return []byte(t.Text), err
+}
+
 func TestInetSet(t *testing.T) {
 	successfulTests := []struct {
 		source interface{}
@@ -60,6 +68,7 @@ func TestInetSet(t *testing.T) {
 		{source: net.ParseIP(""), result: pgtype.Inet{Status: pgtype.Null}},
 		{source: "0.0.0.0/8", result: pgtype.Inet{IPNet: mustParseInet(t, "0.0.0.0/8"), Status: pgtype.Present}},
 		{source: "::ffff:0.0.0.0/104", result: pgtype.Inet{IPNet: &net.IPNet{IP: net.ParseIP("::ffff:0.0.0.0"), Mask: net.CIDRMask(104, 128)}, Status: pgtype.Present}},
+		{source: textMarshaler{"127.0.0.1"}, result: pgtype.Inet{IPNet: mustParseInet(t, "127.0.0.1"), Status: pgtype.Present}},
 		{source: func(s string) fmt.Stringer {
 			var b strings.Builder
 			b.WriteString(s)

--- a/inet_test.go
+++ b/inet_test.go
@@ -1,8 +1,10 @@
 package pgtype_test
 
 import (
+	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgtype"
@@ -58,6 +60,11 @@ func TestInetSet(t *testing.T) {
 		{source: net.ParseIP(""), result: pgtype.Inet{Status: pgtype.Null}},
 		{source: "0.0.0.0/8", result: pgtype.Inet{IPNet: mustParseInet(t, "0.0.0.0/8"), Status: pgtype.Present}},
 		{source: "::ffff:0.0.0.0/104", result: pgtype.Inet{IPNet: &net.IPNet{IP: net.ParseIP("::ffff:0.0.0.0"), Mask: net.CIDRMask(104, 128)}, Status: pgtype.Present}},
+		{source: func(s string) fmt.Stringer {
+			var b strings.Builder
+			b.WriteString(s)
+			return &b
+		}("127.0.0.1"), result: pgtype.Inet{IPNet: mustParseInet(t, "127.0.0.1"), Status: pgtype.Present}},
 	}
 
 	for i, tt := range successfulTests {

--- a/inet_test.go
+++ b/inet_test.go
@@ -93,11 +93,22 @@ func TestInetSet(t *testing.T) {
 	}
 }
 
+type textUnmarshaler struct {
+	Text string
+}
+
+func (u *textUnmarshaler) UnmarshalText(text []byte) error {
+	u.Text = string(text)
+	return nil
+}
+
 func TestInetAssignTo(t *testing.T) {
 	var ipnet net.IPNet
 	var pipnet *net.IPNet
 	var ip net.IP
 	var pip *net.IP
+	var um textUnmarshaler
+	var pum *textUnmarshaler
 
 	simpleTests := []struct {
 		src      pgtype.Inet
@@ -106,8 +117,10 @@ func TestInetAssignTo(t *testing.T) {
 	}{
 		{src: pgtype.Inet{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present}, dst: &ipnet, expected: *mustParseCIDR(t, "127.0.0.1/32")},
 		{src: pgtype.Inet{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present}, dst: &ip, expected: mustParseCIDR(t, "127.0.0.1/32").IP},
+		{src: pgtype.Inet{IPNet: mustParseCIDR(t, "127.0.0.1/32"), Status: pgtype.Present}, dst: &um, expected: textUnmarshaler{"127.0.0.1/32"}},
 		{src: pgtype.Inet{Status: pgtype.Null}, dst: &pipnet, expected: ((*net.IPNet)(nil))},
 		{src: pgtype.Inet{Status: pgtype.Null}, dst: &pip, expected: ((*net.IP)(nil))},
+		{src: pgtype.Inet{Status: pgtype.Null}, dst: &pum, expected: ((*textUnmarshaler)(nil))},
 	}
 
 	for i, tt := range simpleTests {


### PR DESCRIPTION
Primary motivation being support for Go 1.18 [net/netip](https://pkg.go.dev/net/netip)'s Addr and Prefix types.