### PR TITLE
Reset jsonb before unmarshal

### DIFF
--- a/json.go
+++ b/json.go
@@ -107,6 +107,9 @@ func (src *JSON) AssignTo(dst interface{}) error {
 			data = []byte("null")
 		}
 
+		p := reflect.ValueOf(dst).Elem()
+		p.Set(reflect.Zero(p.Type()))
+		
 		return json.Unmarshal(data, dst)
 	}
 


### PR DESCRIPTION
**Issue:**
suppose database table has 2 columns:

| name `varchar(255)` | metadata `jsonb`                              |
| --------------------------- | ----------------------------------------------- |
|           user1               | {"color": "green", "language": "EN"} |
|           user2               | {"language": "DE"}                           |

when reading this table in a loop to a slice of `User` structs
```
type User struct {
	Username string
	Metadata Metadata
}

type Metadata struct {
	Color    string `json:"color"`
	Language string `json:"language"`
}
```

final result would be:
```
[]User{
  {user1 {green EN}},
  {user2 {green DE}} <---
}
```
`"color": "green"` property is present in 2nd struct even though database field doesn't have it. It should be `"color": ""`.

This happens when `rows.Scan` is used in a loop using same struct as a receiver which is then copied to a slice. `json.Unmarshal` doesn't reset struct fields from previous iteration to default values.

**Suggestion:** reset `dst` to default value before calling `json.Unmarshal`
