### PR TITLE
Fix: return correct zero value when UUID conversion fails

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -172,7 +172,7 @@ func underlyingUUIDType(val interface{}) (interface{}, bool) {
 	switch refVal.Kind() {
 	case reflect.Ptr:
 		if refVal.IsNil() {
-			return time.Time{}, false
+			return nil, false
 		}
 		convVal := refVal.Elem().Interface()
 		return convVal, true


### PR DESCRIPTION
Returning `time.Time{}` seems like a typo?