### PR TITLE
Adding support for Ltree binary encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@ jobs:
         PGPASSWORD: secret
         PGSSLMODE: disable
 
+    - name: Create ltree extension
+      run: psql -c 'create extension ltree'
+      env:
+        PGHOST: localhost
+        PGUSER: postgres
+        PGPASSWORD: secret
+        PGSSLMODE: disable
+
     - name: Test
       run: go test -v ./...
       env:

--- a/ltree.go
+++ b/ltree.go
@@ -2,6 +2,7 @@ package pgtype
 
 import (
 	"database/sql/driver"
+	"fmt"
 )
 
 type Ltree Text
@@ -42,7 +43,20 @@ func (dst *Ltree) DecodeText(ci *ConnInfo, src []byte) error {
 }
 
 func (dst *Ltree) DecodeBinary(ci *ConnInfo, src []byte) error {
-	return (*Text)(dst).DecodeBinary(ci, src)
+	if src == nil {
+		*dst = Ltree{Status: Null}
+		return nil
+	}
+
+	// Get Ltree version, only 1 is allowed
+	version := src[0]
+	if version != 1 {
+		return fmt.Errorf("unsupported ltree version %d", version)
+	}
+
+	ltreeStr := string(src[1:])
+	*dst = Ltree{String: ltreeStr, Status: Present}
+	return nil
 }
 
 func (Ltree) PreferredParamFormat() int16 {

--- a/ltree.go
+++ b/ltree.go
@@ -1,0 +1,58 @@
+package pgtype
+
+import (
+	"database/sql/driver"
+)
+
+type Ltree Text
+
+func (dst *Ltree) Set(src interface{}) error {
+	return (*Text)(dst).Set(src)
+}
+
+func (dst Ltree) Get() interface{} {
+	return (Text)(dst).Get()
+}
+
+func (src *Ltree) AssignTo(dst interface{}) error {
+	return (*Text)(src).AssignTo(dst)
+}
+
+func (src Ltree) EncodeText(ci *ConnInfo, buf []byte) ([]byte, error) {
+	return (Text)(src).EncodeText(ci, buf)
+}
+
+func (src Ltree) EncodeBinary(ci *ConnInfo, buf []byte) ([]byte, error) {
+	switch src.Status {
+	case Null:
+		return nil, nil
+	case Undefined:
+		return nil, errUndefined
+	}
+	buf = append(buf, 1)
+	return append(buf, src.String...), nil
+}
+
+func (Ltree) PreferredResultFormat() int16 {
+	return TextFormatCode
+}
+
+func (dst *Ltree) DecodeText(ci *ConnInfo, src []byte) error {
+	return (*Text)(dst).DecodeText(ci, src)
+}
+
+func (dst *Ltree) DecodeBinary(ci *ConnInfo, src []byte) error {
+	return (*Text)(dst).DecodeBinary(ci, src)
+}
+
+func (Ltree) PreferredParamFormat() int16 {
+	return TextFormatCode
+}
+
+func (dst *Ltree) Scan(src interface{}) error {
+	return (*Text)(dst).Scan(src)
+}
+
+func (src Ltree) Value() (driver.Value, error) {
+	return (Text)(src).Value()
+}

--- a/ltree_test.go
+++ b/ltree_test.go
@@ -1,0 +1,50 @@
+package pgtype_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jackc/pgtype"
+	"github.com/jackc/pgtype/testutil"
+)
+
+func TestLtreeTranscode(t *testing.T) {
+	values := []interface{}{
+		&pgtype.Ltree{String: "", Status: pgtype.Present},
+		&pgtype.Ltree{String: "All.foo.one", Status: pgtype.Present},
+		&pgtype.Ltree{Status: pgtype.Null},
+	}
+
+	testutil.TestSuccessfulTranscodeEqFunc(
+		t, "ltree", values, func(ai, bi interface{}) bool {
+			a := ai.(pgtype.Ltree)
+			b := bi.(pgtype.Ltree)
+
+			if a.String != b.String || a.Status != b.Status {
+				return false
+			}
+			return true
+		},
+	)
+
+}
+
+func TestLtreeSet(t *testing.T) {
+	successfulTests := []struct {
+		src    interface{}
+		result pgtype.Ltree
+	}{
+		{src: "All.foo.bar", result: pgtype.Ltree{String: "All.foo.bar", Status: pgtype.Present}},
+		{src: (*string)(nil), result: pgtype.Ltree{Status: pgtype.Null}},
+	}
+	for i, tt := range successfulTests {
+		var dst pgtype.Ltree
+		err := dst.Set(tt.src)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+		if !reflect.DeepEqual(dst, tt.result) {
+			t.Errorf("%d: expected %v to convert to %v, but it was %v", i, tt.src, tt.result, dst)
+		}
+	}
+}

--- a/pgtype.go
+++ b/pgtype.go
@@ -84,7 +84,6 @@ const (
 	TstzrangeArrayOID   = 3911
 	Int8rangeOID        = 3926
 	Int8multirangeOID   = 4536
-	LtreeOID            = 16407
 )
 
 type Status byte
@@ -328,7 +327,6 @@ func NewConnInfo() *ConnInfo {
 	ci.RegisterDataType(DataType{Value: &Varbit{}, Name: "varbit", OID: VarbitOID})
 	ci.RegisterDataType(DataType{Value: &Varchar{}, Name: "varchar", OID: VarcharOID})
 	ci.RegisterDataType(DataType{Value: &XID{}, Name: "xid", OID: XIDOID})
-	ci.RegisterDataType(DataType{Value: &Ltree{}, Name: "ltree", OID: LtreeOID})
 
 	registerDefaultPgTypeVariants := func(name, arrayName string, value interface{}) {
 		ci.RegisterDefaultPgType(value, name)

--- a/pgtype.go
+++ b/pgtype.go
@@ -84,6 +84,7 @@ const (
 	TstzrangeArrayOID   = 3911
 	Int8rangeOID        = 3926
 	Int8multirangeOID   = 4536
+	LtreeOID            = 16407
 )
 
 type Status byte
@@ -327,6 +328,7 @@ func NewConnInfo() *ConnInfo {
 	ci.RegisterDataType(DataType{Value: &Varbit{}, Name: "varbit", OID: VarbitOID})
 	ci.RegisterDataType(DataType{Value: &Varchar{}, Name: "varchar", OID: VarcharOID})
 	ci.RegisterDataType(DataType{Value: &XID{}, Name: "xid", OID: XIDOID})
+	ci.RegisterDataType(DataType{Value: &Ltree{}, Name: "ltree", OID: LtreeOID})
 
 	registerDefaultPgTypeVariants := func(name, arrayName string, value interface{}) {
 		ci.RegisterDefaultPgType(value, name)
@@ -973,6 +975,7 @@ func init() {
 		"jsonb":          &JSONB{},
 		"line":           &Line{},
 		"lseg":           &Lseg{},
+		"ltree":          &Ltree{},
 		"macaddr":        &Macaddr{},
 		"name":           &Name{},
 		"numeric":        &Numeric{},


### PR DESCRIPTION
When used with the COPY protocol, the ltree type would currently result in errors such as:

```
ERROR: unsupported ltree version number 65 (SQLSTATE XX000)
```

This is an attempt to fix this problem by properly adding a byte prefix to the ltree string as implemented by `ltree_send` and `ltree_receive` from the PostgreSQL source:
https://github.com/postgres/postgres/blob/master/contrib/ltree/ltree_io.c#L202 https://github.com/postgres/postgres/blob/master/contrib/ltree/ltree_io.c#L226

I'm actually not entirely sure about all the overloaded methods from `Text` here, I tested through `sqlc` doing `CopyFrom` as well as querying results and things seem to work but I might be missing other things. Let me know if this makes sense. 