### PR TITLE
Support postgres dates with "BC"

### DIFF
--- a/date.go
+++ b/date.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgio"
@@ -138,6 +139,15 @@ func (dst *Date) DecodeText(ci *ConnInfo, src []byte) error {
 	case "-infinity":
 		*dst = Date{Status: Present, InfinityModifier: -Infinity}
 	default:
+		if strings.HasSuffix(sbuf, " BC") {
+			t, err := time.ParseInLocation("2006-01-02", strings.TrimRight(sbuf, " BC"), time.UTC)
+			t2 := time.Date(1-t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
+			if err != nil {
+				return err
+			}
+			*dst = Date{Time: t2, Status: Present}
+			return nil
+		}
 		t, err := time.ParseInLocation("2006-01-02", sbuf, time.UTC)
 		if err != nil {
 			return err

--- a/date_test.go
+++ b/date_test.go
@@ -76,6 +76,7 @@ func TestDateSet(t *testing.T) {
 		{source: time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC), result: pgtype.Date{Time: time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
 		{source: _time(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)), result: pgtype.Date{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
 		{source: "1999-12-31", result: pgtype.Date{Time: time.Date(1999, 12, 31, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
+		{source: "0001-01-01 BC", result: pgtype.Date{Time: time.Date(0000, 01, 01, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
 		{source: customDate{t: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)}, result: pgtype.Date{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), Status: pgtype.Present}},
 	}
 


### PR DESCRIPTION
Postgre is adding the suffix " BC" to dates that occurred "Before Christ". I was unable to parse such values and got `parsing time "0001-01-01 BC": extra text: " BC"` error.
This is caused by the usage of time.ParseInLocation which (for the used layout) does not expect " BC" suffix.