### PR TITLE
Add Scanner and Valuer interfaces to CIDR

### DIFF
--- a/cidr.go
+++ b/cidr.go
@@ -1,5 +1,7 @@
 package pgtype
 
+import "database/sql/driver"
+
 type CIDR Inet
 
 func (dst *CIDR) Set(src interface{}) error {
@@ -28,4 +30,14 @@ func (src CIDR) EncodeText(ci *ConnInfo, buf []byte) ([]byte, error) {
 
 func (src CIDR) EncodeBinary(ci *ConnInfo, buf []byte) ([]byte, error) {
 	return (Inet)(src).EncodeBinary(ci, buf)
+}
+
+// Scan implements the database/sql Scanner interface.
+func (dst *CIDR) Scan(src interface{}) error {
+	return (*Inet)(dst).Scan(src)
+}
+
+// Value implements the database/sql/driver Valuer interface.
+func (src CIDR) Value() (driver.Value, error) {
+	return (Inet)(src).Value()
 }


### PR DESCRIPTION
The PR adds missed Scanner and Valuer interfaces to the CIDR type, which prevents some libraries to behave correctly such as [goqu](https://github.com/doug-martin/goqu).