### PR TITLE
Fix numeric to float64 conversion

### DIFF
--- a/numeric.go
+++ b/numeric.go
@@ -448,7 +448,7 @@ func (src *Numeric) toFloat64() (float64, error) {
 		return math.Inf(-1), nil
 	}
 
-	if src.Exp == 1 {
+	if src.Exp == 0 {
 		return float64(src.Int.Int64()), nil
 	}
 

--- a/numeric.go
+++ b/numeric.go
@@ -448,8 +448,11 @@ func (src *Numeric) toFloat64() (float64, error) {
 		return math.Inf(-1), nil
 	}
 
-	if src.Exp == 1 {
+	switch {
+	case src.Exp == 0:
 		return float64(src.Int.Int64()), nil
+	case src.Exp == 1:
+		return float64(src.Int.Int64() * 10), nil
 	}
 
 	buf := make([]byte, 0, 32)

--- a/numeric.go
+++ b/numeric.go
@@ -448,11 +448,8 @@ func (src *Numeric) toFloat64() (float64, error) {
 		return math.Inf(-1), nil
 	}
 
-	switch {
-	case src.Exp == 0:
+	if src.Exp == 1 {
 		return float64(src.Int.Int64()), nil
-	case src.Exp == 1:
-		return float64(src.Int.Int64() * 10), nil
 	}
 
 	buf := make([]byte, 0, 32)

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -385,6 +385,7 @@ func TestNumericEncodeDecodeBinary(t *testing.T) {
 		123,
 		0.000012345,
 		1.00002345,
+		50.000000,
 		math.NaN(),
 		float32(math.NaN()),
 		math.Inf(1),
@@ -440,5 +441,24 @@ func TestNumericSmallNegativeValues(t *testing.T) {
 
 	if s != "-0.000123" {
 		t.Fatalf("expected %s, got %s", "-0.000123", s)
+	}
+}
+
+// https://github.com/jackc/pgtype/issues/210
+func TestNumericFloat64(t *testing.T) {
+	n := pgtype.Numeric{
+		Int:    big.NewInt(5),
+		Exp:    1,
+		Status: pgtype.Present,
+	}
+
+	var f float64
+	err := n.AssignTo(&f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if f != 50.0 {
+		t.Fatalf("expected %s, got %f", "50", f)
 	}
 }

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -445,20 +445,26 @@ func TestNumericSmallNegativeValues(t *testing.T) {
 }
 
 // https://github.com/jackc/pgtype/issues/210
-func TestNumericFloat64(t *testing.T) {
-	n := pgtype.Numeric{
-		Int:    big.NewInt(5),
-		Exp:    1,
-		Status: pgtype.Present,
-	}
+func TestNumericFloat64FromIntegers(t *testing.T) {
+	for exp := -10; exp <= 10; exp++ {
+		for i := -100; i < 100; i++ {
+			n := pgtype.Numeric{
+				Int:    big.NewInt(int64(i)),
+				Exp:    int32(exp),
+				Status: pgtype.Present,
+			}
 
-	var f float64
-	err := n.AssignTo(&f)
-	if err != nil {
-		t.Fatal(err)
-	}
+			var got float64
+			err := n.AssignTo(&got)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if f != 50.0 {
-		t.Fatalf("expected %s, got %f", "50", f)
+			want := float64(i) * math.Pow10(exp)
+			delta := math.Abs(want * 0.0000000001)
+			if math.Abs(got-want) > delta {
+				t.Fatalf("expected %f from %de%d, got %f", want, i, exp, got)
+			}
+		}
 	}
 }

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -445,7 +445,7 @@ func TestNumericSmallNegativeValues(t *testing.T) {
 }
 
 // https://github.com/jackc/pgtype/issues/210
-func TestNumericFloat64FromIntegers(t *testing.T) {
+func TestNumericFloat64Exhaustive(t *testing.T) {
 	for exp := -10; exp <= 10; exp++ {
 		for i := -100; i < 100; i++ {
 			n := pgtype.Numeric{


### PR DESCRIPTION
A previous optimization in 50933c00 had a logic bug when converting pgtype.Numeric to a float64:

```go
        // BUG: An exponent of one means multiply by 10.
	if src.Exp == 1 {
		return float64(src.Int.Int64()), nil
	}
```

I think the current pgtype.Numeric float64 conversion is incorrect for integers with an exponent of 1, that are divisible by 10, meaning `[10, 20, 30, ..., 90]`.

#210