### PR TITLE
new: allow to override timezone in returned time.Time

### DIFF
--- a/timestamptz.go
+++ b/timestamptz.go
@@ -15,6 +15,8 @@ const pgTimestamptzMinuteFormat = "2006-01-02 15:04:05.999999999Z07:00"
 const pgTimestamptzSecondFormat = "2006-01-02 15:04:05.999999999Z07:00:00"
 const microsecFromUnixEpochToY2K = 946684800 * 1000000
 
+var CustomTimeLocation *time.Location
+
 const (
 	negativeInfinityMicrosecondOffset = -9223372036854775808
 	infinityMicrosecondOffset         = 9223372036854775807
@@ -160,6 +162,9 @@ func (dst *Timestamptz) DecodeBinary(ci *ConnInfo, src []byte) error {
 			microsecFromUnixEpochToY2K/1000000+microsecSinceY2K/1000000,
 			(microsecFromUnixEpochToY2K%1000000*1000)+(microsecSinceY2K%1000000*1000),
 		)
+		if CustomTimeLocation != nil {
+			tim = tim.In(CustomTimeLocation)
+		}
 		*dst = Timestamptz{Time: tim, Status: Present}
 	}
 


### PR DESCRIPTION
github.com/jackc/pgx and github.com/lib/pq behaviour for returned time.Time is different. `pq` uses timezone from connection and returns all `time.Time` in this timezone. 

For example, next code:
```
package main

import (
	"context"
	"log"
	"time"

	"github.com/jackc/pgx/v4"
)

func main() {
	const connStr = "postgres://postgres:qwe123QWE@localhost:5432/postgres?sslmode=disable"
	conn, err := pgx.Connect(context.Background(), connStr)
	if err != nil {
		log.Fatal(err)
	}

	var tz string
	var tm time.Time
	err = conn.QueryRow(context.Background(), "select current_setting('TIMEZONE'), now()").Scan(&tz, &tm)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("current_setting('TIMEZONE'): %s, now(): %v\n", tz, tm)
}
```
print next string
``` 
2024/04/27 21:33:52 current_setting('TIMEZONE'): UTC, now(): 2024-04-27 21:33:52.853171 -0700 MST
```
but similar code with `pq`
```
package main

import (
	"context"
	"database/sql"
	"log"
	"time"

	_ "github.com/lib/pq"
)

func main() {
	const connStr = "postgres://postgres:qwe123QWE@localhost:5432/postgres?sslmode=disable"
	conn, err := sql.Open("postgres", connStr)
	if err != nil {
		log.Fatal(err)
	}

	var tz string
	var tm time.Time
	err = conn.QueryRow("select current_setting('TIMEZONE'), now()").Scan(&tz, &tm)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("current_setting('TIMEZONE'): %s, now(): %v\n", tz, tm)
}
```
returns
```
2024/04/27 21:31:38 current_setting('TIMEZONE'): UTC, now(): 2024-04-28 04:31:38.57887 +0000 UTC
```

This PR allows to override TZ for returned `time.Time` in code, simplifies migration from `pq` to `pgx` and doesn't break any existing code, which use `pgx`

Usage:
```
import (
...
	"github.com/jackc/pgtype"
...
)

func main() {
	pgtype.CustomTimeLocation = time.UTC
...
```

I saw several old topics about such problems (for example, https://stackoverflow.com/questions/72771272/how-to-setup-pgx-to-get-utc-values-from-db)