### PR TITLE
Add pguint64 and xid8 types

### DIFF
--- a/pgtype.go
+++ b/pgtype.go
@@ -84,6 +84,7 @@ const (
 	TstzrangeArrayOID   = 3911
 	Int8rangeOID        = 3926
 	Int8multirangeOID   = 4536
+	XID8OID             = 5069
 )
 
 type Status byte
@@ -327,6 +328,7 @@ func NewConnInfo() *ConnInfo {
 	ci.RegisterDataType(DataType{Value: &Varbit{}, Name: "varbit", OID: VarbitOID})
 	ci.RegisterDataType(DataType{Value: &Varchar{}, Name: "varchar", OID: VarcharOID})
 	ci.RegisterDataType(DataType{Value: &XID{}, Name: "xid", OID: XIDOID})
+	ci.RegisterDataType(DataType{Value: &XID8{}, Name: "xid8", OID: XID8OID})
 
 	registerDefaultPgTypeVariants := func(name, arrayName string, value interface{}) {
 		ci.RegisterDefaultPgType(value, name)

--- a/pguint64.go
+++ b/pguint64.go
@@ -4,7 +4,6 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
-	"math"
 	"strconv"
 
 	"github.com/jackc/pgio"
@@ -25,9 +24,6 @@ func (dst *pguint64) Set(src interface{}) error {
 	case int64:
 		if value < 0 {
 			return fmt.Errorf("%d is less than minimum value for pguint64", value)
-		}
-		if value > math.MaxUint64 {
-			return fmt.Errorf("%d is greater than maximum value for pguint64", value)
 		}
 		*dst = pguint64{Uint: uint64(value), Status: Present}
 	case uint64:

--- a/pguint64.go
+++ b/pguint64.go
@@ -1,0 +1,162 @@
+package pgtype
+
+import (
+	"database/sql/driver"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/jackc/pgio"
+)
+
+// pguint64 is the core type that is used to implement PostgreSQL types such as
+// XID8.
+type pguint64 struct {
+	Uint   uint64
+	Status Status
+}
+
+// Set converts from src to dst. Note that as pguint64 is not a general
+// number type Set does not do automatic type conversion as other number
+// types do.
+func (dst *pguint64) Set(src interface{}) error {
+	switch value := src.(type) {
+	case int64:
+		if value < 0 {
+			return fmt.Errorf("%d is less than minimum value for pguint64", value)
+		}
+		if value > math.MaxUint64 {
+			return fmt.Errorf("%d is greater than maximum value for pguint64", value)
+		}
+		*dst = pguint64{Uint: uint64(value), Status: Present}
+	case uint64:
+		*dst = pguint64{Uint: value, Status: Present}
+	default:
+		return fmt.Errorf("cannot convert %v to pguint64", value)
+	}
+
+	return nil
+}
+
+func (dst pguint64) Get() interface{} {
+	switch dst.Status {
+	case Present:
+		return dst.Uint
+	case Null:
+		return nil
+	default:
+		return dst.Status
+	}
+}
+
+// AssignTo assigns from src to dst. Note that as pguint64 is not a general number
+// type AssignTo does not do automatic type conversion as other number types do.
+func (src *pguint64) AssignTo(dst interface{}) error {
+	switch v := dst.(type) {
+	case *uint64:
+		if src.Status == Present {
+			*v = src.Uint
+		} else {
+			return fmt.Errorf("cannot assign %v into %T", src, dst)
+		}
+	case **uint64:
+		if src.Status == Present {
+			n := src.Uint
+			*v = &n
+		} else {
+			*v = nil
+		}
+	}
+
+	return nil
+}
+
+func (dst *pguint64) DecodeText(ci *ConnInfo, src []byte) error {
+	if src == nil {
+		*dst = pguint64{Status: Null}
+		return nil
+	}
+
+	n, err := strconv.ParseUint(string(src), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*dst = pguint64{Uint: uint64(n), Status: Present}
+	return nil
+}
+
+func (dst *pguint64) DecodeBinary(ci *ConnInfo, src []byte) error {
+	if src == nil {
+		*dst = pguint64{Status: Null}
+		return nil
+	}
+
+	if len(src) != 4 {
+		return fmt.Errorf("invalid length: %v", len(src))
+	}
+
+	n := binary.BigEndian.Uint64(src)
+	*dst = pguint64{Uint: n, Status: Present}
+	return nil
+}
+
+func (src pguint64) EncodeText(ci *ConnInfo, buf []byte) ([]byte, error) {
+	switch src.Status {
+	case Null:
+		return nil, nil
+	case Undefined:
+		return nil, errUndefined
+	}
+
+	return append(buf, strconv.FormatUint(src.Uint, 10)...), nil
+}
+
+func (src pguint64) EncodeBinary(ci *ConnInfo, buf []byte) ([]byte, error) {
+	switch src.Status {
+	case Null:
+		return nil, nil
+	case Undefined:
+		return nil, errUndefined
+	}
+
+	return pgio.AppendUint64(buf, src.Uint), nil
+}
+
+// Scan implements the database/sql Scanner interface.
+func (dst *pguint64) Scan(src interface{}) error {
+	if src == nil {
+		*dst = pguint64{Status: Null}
+		return nil
+	}
+
+	switch src := src.(type) {
+	case uint64:
+		*dst = pguint64{Uint: src, Status: Present}
+		return nil
+	case int64:
+		*dst = pguint64{Uint: uint64(src), Status: Present}
+		return nil
+	case string:
+		return dst.DecodeText(nil, []byte(src))
+	case []byte:
+		srcCopy := make([]byte, len(src))
+		copy(srcCopy, src)
+		return dst.DecodeText(nil, srcCopy)
+	}
+
+	return fmt.Errorf("cannot scan %T", src)
+}
+
+// Value implements the database/sql/driver Valuer interface.
+func (src pguint64) Value() (driver.Value, error) {
+	switch src.Status {
+	case Present:
+		return int64(src.Uint), nil
+	case Null:
+		return nil, nil
+	default:
+		return nil, errUndefined
+	}
+}

--- a/xid8.go
+++ b/xid8.go
@@ -1,0 +1,56 @@
+package pgtype
+
+import (
+	"database/sql/driver"
+)
+
+// XID8 is PostgreSQL's 64 bit Transaction ID type.
+//
+// Another identifier type used by the system is xid, or transaction (abbreviated xact) identifier. This is the data
+// type of the system columns xmin and xmax. Transaction identifiers are 32-bit quantities.
+// In some contexts, a 64-bit variant xid8 is used. Unlike xid values, xid8 values increase strictly monotonically and
+// cannot be reused in the lifetime of a database cluster. See Section 66.1 for more details.
+type XID8 pguint64
+
+// Set converts from src to dst. Note that as XID8 is not a general
+// number type Set does not do automatic type conversion as other number
+// types do.
+func (dst *XID8) Set(src interface{}) error {
+	return (*pguint64)(dst).Set(src)
+}
+
+func (dst XID8) Get() interface{} {
+	return (pguint64)(dst).Get()
+}
+
+// AssignTo assigns from src to dst. Note that as XID8 is not a general number
+// type AssignTo does not do automatic type conversion as other number types do.
+func (src *XID8) AssignTo(dst interface{}) error {
+	return (*pguint64)(src).AssignTo(dst)
+}
+
+func (dst *XID8) DecodeText(ci *ConnInfo, src []byte) error {
+	return (*pguint64)(dst).DecodeText(ci, src)
+}
+
+func (dst *XID8) DecodeBinary(ci *ConnInfo, src []byte) error {
+	return (*pguint64)(dst).DecodeBinary(ci, src)
+}
+
+func (src XID8) EncodeText(ci *ConnInfo, buf []byte) ([]byte, error) {
+	return (pguint64)(src).EncodeText(ci, buf)
+}
+
+func (src XID8) EncodeBinary(ci *ConnInfo, buf []byte) ([]byte, error) {
+	return (pguint64)(src).EncodeBinary(ci, buf)
+}
+
+// Scan implements the database/sql Scanner interface.
+func (dst *XID8) Scan(src interface{}) error {
+	return (*pguint64)(dst).Scan(src)
+}
+
+// Value implements the database/sql/driver Valuer interface.
+func (src XID8) Value() (driver.Value, error) {
+	return (pguint64)(src).Value()
+}


### PR DESCRIPTION
I took a small extract from the postgres docs to attempt document the type.

This is needed to allow watermill-sql to use the xid8 type when using pgx as the database adapter when implementing the outbox pattern.